### PR TITLE
Support for mixpanel's async javascript and javascript order bug fix

### DIFF
--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -9,8 +9,8 @@ class Mixpanel
     clear_queue
   end
 
-  def append_event(event, properties = {})
-    queue << build_event(event, properties)
+  def append_event(event, properties = {}, type = 'track')
+    queue << [type, build_event(event, properties)]
   end
 
   def track_event(event, properties = {})

--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -9,10 +9,14 @@ class Mixpanel
     clear_queue
   end
 
-  def append_event(event, properties = {}, type = 'track')
-    queue << [type, build_event(event, properties)]
+  def append_event(event, properties = {})
+    append_api('track', event, properties)
   end
-
+  
+  def append_api(type, *args)
+    queue << [type, args.map {|arg| arg.to_json}]
+  end
+  
   def track_event(event, properties = {})
     params = build_event(event, properties.merge(:token => @token, :time => Time.now.utc.to_i, :ip => ip))
     parse_response request(params)

--- a/lib/mixpanel/mixpanel_middleware.rb
+++ b/lib/mixpanel/mixpanel_middleware.rb
@@ -107,9 +107,9 @@ class MixpanelMiddleware
     return "" if queue.empty?
 
     if @options[:async]
-      output = queue.map {|event| %(mpq.push(["track", "#{event[:event]}", #{event[:properties].to_json}]);) }.join("\n")
+      output = queue.map {|type, event| %(mpq.push(["#{type}", "#{event[:event]}", #{event[:properties].to_json}]);) }.join("\n")
     else
-      output = queue.map {|event| %(mpmetrics.track("#{event[:event]}", #{event[:properties].to_json});) }.join("\n")
+      output = queue.map {|type, event| %(mpmetrics.#{type}("#{event[:event]}", #{event[:properties].to_json});) }.join("\n")
     end
 
     output = "try {#{output}} catch(err) {}"

--- a/lib/mixpanel/mixpanel_middleware.rb
+++ b/lib/mixpanel/mixpanel_middleware.rb
@@ -28,8 +28,8 @@ class MixpanelMiddleware
       if is_regular_request? && is_html_response?
         insert_at = part.index('</head')
         unless insert_at.nil?
-          part.insert(insert_at, render_mixpanel_scripts)
           part.insert(insert_at, render_event_tracking_scripts) unless queue.empty?
+          part.insert(insert_at, render_mixpanel_scripts) #This will insert the mixpanel initialization code before the queue of tracking events.
         end
       elsif is_ajax_request? && is_html_response?
         part.insert(0, render_event_tracking_scripts) unless queue.empty?

--- a/lib/mixpanel/mixpanel_middleware.rb
+++ b/lib/mixpanel/mixpanel_middleware.rb
@@ -107,9 +107,9 @@ class MixpanelMiddleware
     return "" if queue.empty?
 
     if @options[:async]
-      output = queue.map {|type, event| %(mpq.push(["#{type}", "#{event[:event]}", #{event[:properties].to_json}]);) }.join("\n")
+      output = queue.map {|type, arguments| %(mpq.push(["#{type}", #{arguments.join(', ')}]);) }.join("\n")
     else
-      output = queue.map {|type, event| %(mpmetrics.#{type}("#{event[:event]}", #{event[:properties].to_json});) }.join("\n")
+      output = queue.map {|type, arguments| %(mpmetrics.#{type}(#{arguments.join(', ')});) }.join("\n")
     end
 
     output = "try {#{output}} catch(err) {}"

--- a/spec/mixpanel/mixpanel_middleware_spec.rb
+++ b/spec/mixpanel/mixpanel_middleware_spec.rb
@@ -14,6 +14,66 @@ describe MixpanelMiddleware do
     end
   end
 
+  describe "Appending async mixpanel scripts" do
+    describe "With ajax requests" do
+      before do
+        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        get "/", {}, {"HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
+      end
+
+      it "should not append mixpanel scripts to head element" do
+        Nokogiri::HTML(last_response.body).search('script').should be_empty
+      end
+
+      it "should not update Content-Length in headers" do
+        last_response.headers["Content-Length"].should == html_document.length.to_s
+      end
+    end
+    
+    describe "With large ajax response" do
+      before do
+        setup_rack_application(DummyApp, {:body => large_script, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        get "/", {}, {"HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
+      end
+      
+      it "should not append mixpanel scripts to head element" do
+        last_response.body.index('var mp_protocol').should be_nil
+      end
+
+      it "should pass through if the document is not text/html content type" do
+        last_response.body.should == large_script
+      end
+    end
+    
+    describe "With regular requests" do
+      before do
+        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        get "/"
+      end
+
+      it "should append mixpanel scripts to head element" do
+        Nokogiri::HTML(last_response.body).search('head script').should_not be_empty
+        Nokogiri::HTML(last_response.body).search('body script').should be_empty
+      end
+
+      it "should have 1 included script" do
+        Nokogiri::HTML(last_response.body).search('script').size.should == 1
+      end
+
+      it "should use the specified token instantiating mixpanel lib" do
+        last_response.should =~ /mpq.push\(\["init", "#{MIX_PANEL_TOKEN}"\]\)/
+      end
+
+      it "should define Content-Length if not exist" do
+        last_response.headers.has_key?("Content-Length").should == true
+      end
+
+      it "should update Content-Length in headers" do
+        last_response.headers["Content-Length"].should_not == html_document.length.to_s
+      end
+    end
+  end
+
   describe "Appending mixpanel scripts" do
     describe "With ajax requests" do
       before do
@@ -70,6 +130,79 @@ describe MixpanelMiddleware do
 
       it "should update Content-Length in headers" do
         last_response.headers["Content-Length"].should_not == html_document.length.to_s
+      end
+    end
+  end
+
+  describe "Tracking async appended events" do
+    before do
+      @mixpanel = Mixpanel.new(MIX_PANEL_TOKEN, {})
+      @mixpanel.append_event("Visit", {:article => 1})
+      @mixpanel.append_event("Sign in")
+    end
+
+    describe "With ajax requests and text/html response" do
+      before do
+        setup_rack_application(DummyApp, {:body => "<p>response</p>", :headers => {"Content-Type" => "text/html"}}, {:async => true})
+
+        get "/", {}, {"mixpanel_events" => @mixpanel.queue, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
+      end
+
+      it "should render only one script tag" do
+        Nokogiri::HTML(last_response.body).search('script').size.should == 1
+      end
+
+      it "should be tracking the correct events inside a script tag" do
+        script = Nokogiri::HTML(last_response.body).search('script')
+        script.inner_html.should =~ /try\s?\{(.*)\}\s?catch/m
+        script.inner_html.should =~ /mpq\.push\(\["track",\s?"Visit",\s?\{"article":1\}\]\)/
+        script.inner_html.should =~ /mpq\.push\(\["track",\s?"Sign in",\s?\{\}\]\)/
+      end
+
+      it "should delete events queue after use it" do
+        last_request.env.has_key?("mixpanel_events").should == false
+      end
+    end
+
+    describe "With ajax requests and text/javascript response" do
+      before do
+        setup_rack_application(DummyApp, {:body => "alert('response')", :headers => {"Content-Type" => "text/javascript"}}, {:async => true})
+        get "/", {}, {"mixpanel_events" => @mixpanel.queue, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
+      end
+
+      it "should not render a script tag" do
+        Nokogiri::HTML(last_response.body).search('script').size.should == 0
+      end
+
+      it "should be tracking the correct events inside a try/catch" do
+        script = last_response.body.match(/try\s?\{(.*)\}\s?catch/m)[1]
+        script.should =~ /mpq\.push\(\["track",\s?"Visit",\s?\{"article":1\}\]\)/
+        script.should =~ /mpq\.push\(\["track",\s?"Sign in",\s?\{\}\]\)/
+      end
+
+      it "should delete events queue after use it" do
+        last_request.env.has_key?("mixpanel_events").should == false
+      end
+    end
+
+    describe "With regular requests" do
+      before do
+        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+
+        get "/", {}, {"mixpanel_events" => @mixpanel.queue}
+      end
+
+      it "should render 2 script tags" do
+        Nokogiri::HTML(last_response.body).search('script').size.should == 2
+      end
+
+      it "should be tracking the correct events" do
+        last_response.body.should =~ /mpq\.push\(\["track",\s?"Visit",\s?\{"article":1\}\]\)/
+        last_response.body.should =~ /mpq\.push\(\["track",\s?"Sign in",\s?\{\}\]\)/
+      end
+
+      it "should delete events queue after use it" do
+        last_request.env.has_key?("mixpanel_events").should == false
       end
     end
   end

--- a/spec/mixpanel/mixpanel_spec.rb
+++ b/spec/mixpanel/mixpanel_spec.rb
@@ -48,17 +48,37 @@ describe Mixpanel do
 
       it "should append simple events" do
         @mixpanel.append_event("Sign up")
-        mixpanel_queue_should_include(@mixpanel, "Sign up", {})
+        mixpanel_queue_should_include(@mixpanel, "track", "Sign up", {})
       end
 
       it "should append events with properties" do
         @mixpanel.append_event("Sign up", {:referer => 'http://example.com'})
-        mixpanel_queue_should_include(@mixpanel, "Sign up", {:referer => 'http://example.com'})
+        mixpanel_queue_should_include(@mixpanel, "track", "Sign up", {:referer => 'http://example.com'})
       end
 
       it "should give direct access to queue" do
         @mixpanel.append_event("Sign up", {:referer => 'http://example.com'})
         @mixpanel.queue.size.should == 1
+      end
+      
+      it "should provide direct access to the JS api" do
+        @mixpanel.append_api('track', "Sign up", {:referer => 'http://example.com'})
+        mixpanel_queue_should_include(@mixpanel, "track", "Sign up", {:referer => 'http://example.com'})
+      end
+      
+      it "should allow identify to be called through the JS api" do
+        @mixpanel.append_api('identify', "some@one.com")
+        mixpanel_queue_should_include(@mixpanel, "identify", "some@one.com")
+      end
+
+      it "should allow identify to be called through the JS api" do
+        @mixpanel.append_api('identify', "some@one.com")
+        mixpanel_queue_should_include(@mixpanel, "identify", "some@one.com")
+      end
+      
+      it "should allow the tracking of super properties in JS" do
+        @mixpanel.append_api('register', {:user_id => 12345, :email => "some@one.com"})
+        mixpanel_queue_should_include(@mixpanel, 'register', {:user_id => 12345, :email => "some@one.com"})
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].e
 MIX_PANEL_TOKEN = "e2d8b0bea559147844ffab3d607d26a6"
 
 def mixpanel_queue_should_include(mixpanel, event, properties)
-  mixpanel.queue.each do |event_hash|
+  mixpanel.queue.each do |type, event_hash|
     event_hash[:event].should == event
     event_hash[:properties].should == properties if properties
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,11 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].e
 
 MIX_PANEL_TOKEN = "e2d8b0bea559147844ffab3d607d26a6"
 
-def mixpanel_queue_should_include(mixpanel, event, properties)
-  mixpanel.queue.each do |type, event_hash|
-    event_hash[:event].should == event
-    event_hash[:properties].should == properties if properties
+
+def mixpanel_queue_should_include(mixpanel, type, *arguments)
+  mixpanel.queue.each do |event_type, event_arguments|
+    event_arguments.should == arguments.map{|arg| arg.to_json}
+    event_type.should == type
   end
 end
 

--- a/spec/support/rack_apps.rb
+++ b/spec/support/rack_apps.rb
@@ -1,5 +1,5 @@
-def setup_rack_application(application, options = {})
-  stub!(:app).and_return(MixpanelMiddleware.new(application.new(options), MIX_PANEL_TOKEN))
+def setup_rack_application(application, options = {}, mixpanel_options = {})
+  stub!(:app).and_return(MixpanelMiddleware.new(application.new(options), MIX_PANEL_TOKEN, mixpanel_options))
 end
 
 def html_document


### PR DESCRIPTION
Hey,

This patch lets you use pass :async => true to the middleware.use line to get mixpanel's asynchronous javascript rather than the standard one. It also includes a bug fix. The .insert_at code was running in the wrong order. It inserted the initialization code at point x and then inserted the queue code at point x, thereby putting the queue code before the initialization. I reversed the ordering which makes events track properly when passed to javascript.
