### PR TITLE
Asynchronous reporting via a background process

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,7 +33,7 @@ In your application_controller class add a method to instance mixpanel.
   before_filter :initialize_mixpanel
 
   def initialize_mixpanel
-    @mixpanel = Mixpanel.new("YOUR_MIXPANEL_API_TOKEN", request.env)
+    @mixpanel = Mixpanel.new("YOUR_MIXPANEL_API_TOKEN", request.env, true)
   end
 
 Then in each request you want to track some event you can use:
@@ -54,12 +54,13 @@ To execute any javascript API call
 
 == Notes
 
-It is strongly recommended to call Mixpanel#track_event using an async lib
-like delayed job or similar, otherwise you will delay your server responses
-with mixpanel responses.
+There are two forms of async operation: 
+* Using MixpanelMiddleware, events are queued via Mixpanel#append_event and inserted into a JavaScript block within the HTML response.  
+* Using Mixpanel.new(…, …, true), events are sent to a subprocess via a pipe and the sub process which asynchronously send events to Mixpanel.  This process uses a single thread to upload events, and may start dropping events if your application generates them at a very high rate.  
 
 == Collaborators and Maintainers
 
 * {Alvaro Gil}[https://github.com/zevarito] (Author)
 * {Nathan Baxter}[https://github.com/LogicWolfe]
 * {Jake Mallory}[https://github.com/tinomen]
+* {Logan Bowers}[https://github.com/loganb]

--- a/lib/mixpanel/mixpanel_subprocess.rb
+++ b/lib/mixpanel/mixpanel_subprocess.rb
@@ -1,0 +1,30 @@
+
+require 'rubygems'
+require 'mixpanel'
+require 'open-uri'
+
+require 'thread'
+
+class Mixpanel::Subprocess
+  Q = Queue.new
+  ENDMARKER = Object.new
+
+  Thread.abort_on_exception = true
+  producer = Thread.new do 
+    STDIN.each_line() do |url|
+      STDERR.puts("Dropped: #{url}") && next if Q.length > 10000
+      Q << url
+    end
+    Q << ENDMARKER
+  end
+
+  loop do
+    url = Q.pop
+    break if(url == ENDMARKER)
+    url.chomp!
+    next if(url.empty?) #for testing
+  
+    open(url).read
+  end
+  producer.join
+end

--- a/mixpanel.gemspec
+++ b/mixpanel.gemspec
@@ -2,7 +2,7 @@ files = ['README.rdoc', 'LICENSE', 'Rakefile', 'mixpanel.gemspec', '{spec,lib}/*
 
 spec = Gem::Specification.new do |s|
   s.name = "mixpanel"
-  s.version = "0.7.0"
+  s.version = "0.7.1"
   s.rubyforge_project = "mixpanel"
   s.description = "Simple lib to track events in Mixpanel service. It can be used in any rack based framework."
   s.author = "Alvaro Gil"

--- a/mixpanel.gemspec
+++ b/mixpanel.gemspec
@@ -16,6 +16,7 @@ spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.rdoc"]
   s.add_dependency 'json'
   s.add_dependency 'rack'
+  s.add_dependency 'escape'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'fakeweb'

--- a/spec/mixpanel/mixpanel_spec.rb
+++ b/spec/mixpanel/mixpanel_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Mixpanel do
-  before do
+  before(:each) do
     @mixpanel = Mixpanel.new(MIX_PANEL_TOKEN, @env = {"REMOTE_ADDR" => "127.0.0.1"})
   end
 
@@ -80,6 +80,34 @@ describe Mixpanel do
         @mixpanel.append_api('register', {:user_id => 12345, :email => "some@one.com"})
         mixpanel_queue_should_include(@mixpanel, 'register', {:user_id => 12345, :email => "some@one.com"})
       end
+    end
+  end
+  
+  context "Accessing Mixpanel asynchronously" do
+    it "should open a subprocess successfully" do
+      w = Mixpanel.worker
+      w.should == Mixpanel.worker
+    end
+    
+    it "should be able to write lines to the worker" do
+      w = Mixpanel.worker
+      
+      #On most systems this will exceed the pipe buffer size
+      8.times do
+        9000.times do 
+          w.write("\n")
+        end
+        sleep 0.1
+      end
+    end
+    
+    it "should dispose of a worker" do
+      w = Mixpanel.worker
+      Mixpanel.dispose_worker(w)
+      
+      w.closed?.should == true
+      w2 = Mixpanel.worker
+      w2.should_not == w
     end
   end
 end


### PR DESCRIPTION
Hello, 

I added support for spawning a background process to send events to Mixpanel asynchronously and included some rudimentary tests.  It is not heavily tested (yet), but it would be great to get it included in the mainline.  
