### PR TITLE
Track events that happen on the client side which does not hit the server

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -46,6 +46,11 @@ To track events after response with javascript...
 
   @mixpanel.append_event("Sign in", {:some => "property"})
 
+To track an event based on users actions that do not hit your server, use javascript:
+
+  @mixpanel.append_event_with_js('Click a div',
+          lambda {|code| "$('#divid').click(function() { #{code} });" }, {:some => "property"})
+
 To execute any javascript API call
 
   @mixpanel.append_api("register", {:some => "property"})

--- a/README.rdoc
+++ b/README.rdoc
@@ -46,7 +46,7 @@ To track events after response with javascript...
 
   @mixpanel.append_event("Sign in", {:some => "property"})
 
-To track an event based on users actions that do not hit your server, use javascript:
+To track an event based on users actions that do not hit your server, wrap javascript around the code to listen for the interaction:
 
   @mixpanel.append_event_with_js('Click a div',
           lambda {|code| "$('#divid').click(function() { #{code} });" }, {:some => "property"})

--- a/README.rdoc
+++ b/README.rdoc
@@ -49,7 +49,7 @@ To track events after response with javascript...
 To track an event based on users actions that do not hit your server, wrap javascript around the code to listen for the interaction:
 
   @mixpanel.append_event_with_js('Click a div',
-          lambda {|code| "$('#divid').click(function() { #{code} });" }, {:some => "property"})
+          lambda {|code| "$('#div_id').click(function() { #{code} });" }, {:some => "property"})
 
 To execute any javascript API call
 

--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -17,7 +17,7 @@ class Mixpanel
     if js_block.nil?
       append_api('track', event, properties)
     else
-      queue << [js_block, 'track', [event.to_json, properties.to_json]]
+      queue << [js_block, 'track', [event, properties].map {|arg| arg.to_json} ]
     end
   end
   

--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -13,12 +13,12 @@ class Mixpanel
   end
   
   # To track events after response with javascript...
-  def append_event(event, js_block = nil, properties = {})
-    if js_block.nil?
-      append_api('track', event, properties)
-    else
-      queue << ['track', js_block, [event, properties].map {|arg| arg.to_json} ]
-    end
+  def append_event(event, properties = {})
+    queue << ['track', nil, [event, properties].map {|arg| arg.to_json} ]
+  end
+  
+  def append_event_with_js(event, js_block, properties = {})
+    queue << ['track', js_block, [event, properties].map {|arg| arg.to_json} ]
   end
   
   # To execute any javascript API call...

--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -13,11 +13,11 @@ class Mixpanel
   end
   
   # To track events after response with javascript...
-  def append_event(js_block = nil, event, properties = {})
+  def append_event(event, js_block = nil, properties = {})
     if js_block.nil?
       append_api('track', event, properties)
     else
-      queue << [js_block, 'track', [event, properties].map {|arg| arg.to_json} ]
+      queue << ['track', js_block, [event, properties].map {|arg| arg.to_json} ]
     end
   end
   

--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -11,15 +11,23 @@ class Mixpanel
     @async = async
     clear_queue
   end
-
+  
+  # To track events after response with javascript...
   def append_event(event, properties = {})
     append_api('track', event, properties)
   end
   
+  # To track events that should be binded to DOM elements
+  def append_event_to_div(dom, event, properties = {})
+    queue2 << [dom, 'track', [event.to_json, properties.to_json]]
+  end
+  
+  # To execute any javascript API call...
   def append_api(type, *args)
     queue << [type, args.map {|arg| arg.to_json}]
   end
   
+  # To track events directly from your backend...
   def track_event(event, properties = {})
     params = build_event(event, properties.merge(:token => @token, :time => Time.now.utc.to_i, :ip => ip))
     parse_response request(params)
@@ -31,6 +39,10 @@ class Mixpanel
 
   def queue
     @env["mixpanel_events"]
+  end
+  
+  def queue2
+    @env["mixpanel_events_2"]
   end
 
   def clear_queue

--- a/lib/mixpanel/mixpanel.rb
+++ b/lib/mixpanel/mixpanel.rb
@@ -13,13 +13,12 @@ class Mixpanel
   end
   
   # To track events after response with javascript...
-  def append_event(event, properties = {})
-    append_api('track', event, properties)
-  end
-  
-  # To track events that should be binded to DOM elements
-  def append_event_to_div(dom, event, properties = {})
-    queue2 << [dom, 'track', [event.to_json, properties.to_json]]
+  def append_event(js_block = nil, event, properties = {})
+    if js_block.nil?
+      append_api('track', event, properties)
+    else
+      queue << [js_block, 'track', [event.to_json, properties.to_json]]
+    end
   end
   
   # To execute any javascript API call...
@@ -39,10 +38,6 @@ class Mixpanel
 
   def queue
     @env["mixpanel_events"]
-  end
-  
-  def queue2
-    @env["mixpanel_events_2"]
   end
 
   def clear_queue

--- a/lib/mixpanel/mixpanel_middleware.rb
+++ b/lib/mixpanel/mixpanel_middleware.rb
@@ -128,6 +128,10 @@ class MixpanelMiddleware
     output = output_array.join("\n")
     output = "try {#{output}} catch(err) {}"
 
-    include_script_tag ? "<script type='text/javascript'>#{output}</script>" : output
+    if include_script_tag
+      "<script type='text/javascript'>jQuery(document).ready(function() { #{output} });</script>"
+    else
+      output
+    end
   end
 end

--- a/lib/mixpanel/mixpanel_middleware.rb
+++ b/lib/mixpanel/mixpanel_middleware.rb
@@ -108,19 +108,19 @@ class MixpanelMiddleware
     output = ""
     
     if @options[:async]
-      output_array = queue.map do |js_block, type, arguments|
+      output_array = queue.map do |type, js_block, arguments|
         if js_block.nil?
           %(mpq.push(["#{type}", #{arguments.join(', ')}]);)
         else
-          js_block.call %(mpq.push(["#{type}", #{arguments.join(', ')}]);)
+          js_block.call("mpq.push([\"#{type}\", #{arguments.join(', ')}]);")
         end
       end
     else
-      output_array = queue.map do |js_block, type, arguments|
+      output_array = queue.map do |type, js_block, arguments|
         if js_block.nil?
-          %(mpmetrics.#{type}(#{arguments.join(', ')});)
+          "mpmetrics.#{type}(#{arguments.join(', ')});"
         else
-          js_block.call %(mpmetrics.#{type}(#{arguments.join(', ')});)
+          js_block.call("mpmetrics.#{type}(#{arguments.join(', ')});")
         end
       end
     end


### PR DESCRIPTION
Hi, I made some changes to the mixpanel gem to allow people to wrap javascript around the events that will be tracked. It's useful to track users interactions that do not hit the server.

Example: A user click on a registration form that's a lightbox (server doesn't get hit, but this event should still be tracked)

```
@mixpanel.append_event_with_js('Click beta request',
      lambda {|code| "$('#beta-request').click(function() { #{code} });" },
      {:from_page => "Home page"})
```
