### PR TITLE
Updated middleware.rb with latest mixpanel javascript

### DIFF
--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -69,11 +69,7 @@ module Mixpanel
           <script type='text/javascript'>
             var mpq = [];
             mpq.push(["init", "#{@token}"]);
-            (function() {
-            var mp = document.createElement("script"); mp.type = "text/javascript"; mp.async = true;
-            mp.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + "//api.mixpanel.com/site_media/js/api/mixpanel.js";
-            var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(mp, s);
-            })();
+            (function(){var b,a,e,d,c;b=document.createElement("script");b.type="text/javascript";b.async=true;b.src=(document.location.protocol==="https:"?"https:":"http:")+"//api.mixpanel.com/site_media/js/api/mixpanel.js";a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(b,a);e=function(f){return function(){mpq.push([f].concat(Array.prototype.slice.call(arguments,0)))}};d=["track","track_links","track_forms","register","register_once","identify","name_tag","set_config"];for(c=0;c<d.length;c++){mpq[d[c]]=e(d[c])}})();
           </script>
             EOT
         else


### PR DESCRIPTION
I updated the javascript in middleware.rb with the latest javascript in the docs (http://mixpanel.com/api/docs/guides/integration/js). This should enable people to call mpq.track_links and the like directly from javascript.
