### PR TITLE
Allow overriding of token, time, and ip address

### DIFF
--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -22,7 +22,9 @@ module Mixpanel
     end
 
     def track_event(event, properties = {})
-      params = build_event(event, properties.merge(:token => @token, :time => Time.now.utc.to_i, :ip => ip))
+      options = { :token => @token, :time => Time.now.utc.to_i, :ip => ip }
+      options.merge!(properties)
+      params = build_event(event, options)
       parse_response request(params)
     end
 


### PR DESCRIPTION
This lets clients pass in token, ip, and time to track_event.

(This was a problem, because the IP address in my requests REMOTE_ADDR isn't correct, so I want to pass in a different IP address)
