### PR TITLE
Add option to insert scripts before </body> instead of </head> for faster rendering

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,6 +28,12 @@ If you want to use the asynchronous version of Mixpanel's javascript API
 
     config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :async => true
 
+By default the scripts are inserted into the head of the html response. If you'd prefer the scripts to run after all rendering has completed you can set the `insert_js_last` flag and they'll be added at the end of the body tag:
+
+  Rails::Initializer.run do |config|
+
+    config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :async => true, :insert_js_last => true
+
 In your application_controller class add a method to instance mixpanel.
 
   before_filter :initialize_mixpanel

--- a/README.rdoc
+++ b/README.rdoc
@@ -28,9 +28,7 @@ If you want to use the asynchronous version of Mixpanel's javascript API
 
     config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :async => true
 
-By default the scripts are inserted into the head of the html response.
-If you'd prefer the scripts to run after all rendering has completed you
-can set the insert_js_last flag and they'll be added at the end of the body tag:
+By default the scripts are inserted into the head of the html response. If you'd prefer the scripts to run after all rendering has completed you can set the insert_js_last flag and they'll be added at the end of the body tag. This will work whether or not you opt for the aynchronous version of the API. However, when inserting js into an ajax response it will have no effect:
 
   Rails::Initializer.run do |config|
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,9 @@ If you want to use the asynchronous version of Mixpanel's javascript API
 
     config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :async => true
 
-By default the scripts are inserted into the head of the html response. If you'd prefer the scripts to run after all rendering has completed you can set the `insert_js_last` flag and they'll be added at the end of the body tag:
+By default the scripts are inserted into the head of the html response.
+If you'd prefer the scripts to run after all rendering has completed you
+can set the insert_js_last flag and they'll be added at the end of the body tag:
 
   Rails::Initializer.run do |config|
 

--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -8,7 +8,7 @@ module Mixpanel
         @token = mixpanel_token
         @options = {
           :async => false,
-          :insert_js_last => true
+          :insert_js_last => false
         }.merge(options)
       end
 

--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -7,7 +7,8 @@ module Mixpanel
         @app = app
         @token = mixpanel_token
         @options = {
-          :async => false
+          :async => false,
+          :insert_js_last => true
         }.merge(options)
       end
 
@@ -28,7 +29,7 @@ module Mixpanel
       def update_response!
         @response.each do |part|
           if is_regular_request? && is_html_response?
-            insert_at = part.index('</head')
+            insert_at = part.index(@options[:insert_js_last] ? '</body' : '</head')
             unless insert_at.nil?
               part.insert(insert_at, render_event_tracking_scripts) unless queue.empty?
               part.insert(insert_at, render_mixpanel_scripts) #This will insert the mixpanel initialization code before the queue of tracking events.

--- a/spec/mixpanel/tracker/middleware_spec.rb
+++ b/spec/mixpanel/tracker/middleware_spec.rb
@@ -46,30 +46,44 @@ describe Mixpanel::Tracker::Middleware do
     end
     
     describe "With regular requests" do
-      before do
-        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true})
-        get "/"
+      describe "With js in head" do
+        before do
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true, :insert_js_last => false})
+          get "/"
+        end
+
+        it "should append mixpanel scripts to head element" do
+          Nokogiri::HTML(last_response.body).search('head script').should_not be_empty
+          Nokogiri::HTML(last_response.body).search('body script').should be_empty
+        end
+
+        it "should have 1 included script" do
+          Nokogiri::HTML(last_response.body).search('script').size.should == 1
+        end
+
+        it "should use the specified token instantiating mixpanel lib" do
+          last_response.should =~ /mpq.push\(\["init", "#{MIX_PANEL_TOKEN}"\]\)/
+        end
+
+        it "should define Content-Length if not exist" do
+          last_response.headers.has_key?("Content-Length").should == true
+        end
+
+        it "should update Content-Length in headers" do
+          last_response.headers["Content-Length"].should_not == html_document.length.to_s
+        end
       end
 
-      it "should append mixpanel scripts to head element" do
-        Nokogiri::HTML(last_response.body).search('head script').should_not be_empty
-        Nokogiri::HTML(last_response.body).search('body script').should be_empty
-      end
+      describe "With js last" do
+        before do
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true, :insert_js_last => true})
+          get "/"
+        end
 
-      it "should have 1 included script" do
-        Nokogiri::HTML(last_response.body).search('script').size.should == 1
-      end
-
-      it "should use the specified token instantiating mixpanel lib" do
-        last_response.should =~ /mpq.push\(\["init", "#{MIX_PANEL_TOKEN}"\]\)/
-      end
-
-      it "should define Content-Length if not exist" do
-        last_response.headers.has_key?("Content-Length").should == true
-      end
-
-      it "should update Content-Length in headers" do
-        last_response.headers["Content-Length"].should_not == html_document.length.to_s
+        it "should append mixpanel scripts to end of body element" do
+          Nokogiri::HTML(last_response.body).search('head script').should be_empty
+          Nokogiri::HTML(last_response.body).search('body script').should_not be_empty
+        end
       end
     end
   end
@@ -106,30 +120,44 @@ describe Mixpanel::Tracker::Middleware do
     end
     
     describe "With regular requests" do
-      before do
-        setup_rack_application(DummyApp, :body => html_document, :headers => {"Content-Type" => "text/html"})
-        get "/"
+      describe "With js in head" do
+        before do
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:insert_js_last => false})
+          get "/"
+        end
+
+        it "should append mixpanel scripts to head element" do
+          Nokogiri::HTML(last_response.body).search('head script').should_not be_empty
+          Nokogiri::HTML(last_response.body).search('body script').should be_empty
+        end
+
+        it "should have 2 included scripts" do
+          Nokogiri::HTML(last_response.body).search('script').size.should == 2
+        end
+
+        it "should use the specified token instantiating mixpanel lib" do
+          last_response.should =~ /new MixpanelLib\('#{MIX_PANEL_TOKEN}'\)/
+        end
+
+        it "should define Content-Length if not exist" do
+          last_response.headers.has_key?("Content-Length").should == true
+        end
+
+        it "should update Content-Length in headers" do
+          last_response.headers["Content-Length"].should_not == html_document.length.to_s
+        end
       end
 
-      it "should append mixpanel scripts to head element" do
-        Nokogiri::HTML(last_response.body).search('head script').should_not be_empty
-        Nokogiri::HTML(last_response.body).search('body script').should be_empty
-      end
+      describe "With js last" do
+        before do
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:insert_js_last => true})
+          get "/"
+        end
 
-      it "should have 2 included scripts" do
-        Nokogiri::HTML(last_response.body).search('script').size.should == 2
-      end
-
-      it "should use the specified token instantiating mixpanel lib" do
-        last_response.should =~ /new MixpanelLib\('#{MIX_PANEL_TOKEN}'\)/
-      end
-
-      it "should define Content-Length if not exist" do
-        last_response.headers.has_key?("Content-Length").should == true
-      end
-
-      it "should update Content-Length in headers" do
-        last_response.headers["Content-Length"].should_not == html_document.length.to_s
+        it "should append mixpanel scripts to end of body element" do
+          Nokogiri::HTML(last_response.body).search('head script').should be_empty
+          Nokogiri::HTML(last_response.body).search('body script').should_not be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
I've added an insert_js_last option that ensures all scripts are added after all content, just before the </body> tag for faster rendering, since rendering halts for inline scripts.

Practicing being opinionated I've made this option true by default, it shouldn't cause backwards compatibility problems and it will result in (slightly) faster render times for the average user.

I've updated the specs as well.
