### PR TITLE
Mixpanel logger configuration

### DIFF
--- a/lib/mixpanel.rb
+++ b/lib/mixpanel.rb
@@ -1,3 +1,5 @@
+require 'logger'
+require 'mixpanel/configuration'
 require 'mixpanel/tracker'
 
 module Mixpanel

--- a/lib/mixpanel/configuration.rb
+++ b/lib/mixpanel/configuration.rb
@@ -1,0 +1,21 @@
+module Mixpanel
+  class Configuration
+    class << self
+      attr_writer :logger
+    end
+
+    def self.logger
+      @logger ||= _default_logger
+    end
+
+    def logger
+      @logger ||= self.class._default_logger
+    end
+
+    def self._default_logger
+      logger = defined?(Rails) ? Rails.logger : Logger.new("/dev/null")
+      logger.level = Logger::DEBUG
+      logger
+    end
+  end
+end

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -14,6 +14,7 @@ module Mixpanel
     end
 
     def append_event(event, properties = {})
+      write_log(event, properties)
       append_api('track', event, properties)
     end
 
@@ -24,6 +25,8 @@ module Mixpanel
     def track_event(event, properties = {})
       options = { :token => @token, :time => Time.now.utc.to_i, :ip => ip }
       options.merge!(properties)
+
+      write_log(event, options)
       params = build_event(event, options)
       parse_response request(params)
     end
@@ -38,6 +41,10 @@ module Mixpanel
 
     def clear_queue
       @env["mixpanel_events"] = []
+    end
+
+    def write_log(event, options)
+      Configuration.logger.debug "[Mixpanel] [#{current_time}] #{event} with properties: #{options}"
     end
 
     class <<self
@@ -70,6 +77,10 @@ module Mixpanel
     end
 
     private
+
+    def current_time
+      Time.now.utc.strftime("%d/%b/%Y %H:%M:%S %Z")
+    end
 
     def parse_response(response)
       response == "1" ? true : false

--- a/spec/mixpanel/configuration_spec.rb
+++ b/spec/mixpanel/configuration_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Mixpanel::Configuration do
+  describe "logger" do
+    it "defaults to logging to stdout with log_level info" do
+      config = Mixpanel::Configuration.new
+      config.logger.level.should == Logger::DEBUG
+    end
+
+    it "lazily initializes so that you can do Mixpanel::Configuration.logger.level = when configuring the client lib" do
+      config = Mixpanel::Configuration.new :logger => nil
+      config.logger.should_not == nil
+    end
+  end
+
+  describe "self.logger" do
+    it "lazily initializes so that you can do Mixpanel::Configuration.logger.level = when configuring the client lib" do
+      Mixpanel::Configuration.logger = nil
+      Mixpanel::Configuration.logger.should_not == nil
+    end
+  end
+
+end

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -7,7 +7,7 @@ describe Mixpanel::Tracker do
 
   context "Initializing object" do
     it "should have an instance variable for token and events" do
-      @mixpanel.instance_variables.should include("@token", "@env")
+      @mixpanel.instance_variables.should include(:@token, :@env, :@async)
     end
   end
 

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -23,7 +23,14 @@ describe Mixpanel::Tracker do
   context "Accessing Mixpanel through direct request" do
     context "Tracking events" do
       it "should track simple events" do
-        @mixpanel.track_event("Sign up").should == true
+        now_in_utc = Time.utc(2009, 10, 10, 13, 55, 36)
+        SpecHelper.stub_time_dot_now(now_in_utc) do
+          output = StringIO.new
+          Mixpanel::Configuration.logger = Logger.new(output)
+          @mixpanel.track_event("Sign up").should == true
+
+          output.string.should include("[Mixpanel] [10/Oct/2009 13:55:36 UTC] Sign up with properties:")
+        end
       end
 
       it "should call request method with token and time value" do
@@ -49,6 +56,17 @@ describe Mixpanel::Tracker do
       it "should append simple events" do
         @mixpanel.append_event("Sign up")
         mixpanel_queue_should_include(@mixpanel, "track", "Sign up", {})
+      end
+
+      it "should write to log" do
+        now_in_utc = Time.utc(2009, 10, 10, 13, 55, 36)
+        SpecHelper.stub_time_dot_now(now_in_utc) do
+          output = StringIO.new
+          Mixpanel::Configuration.logger = Logger.new(output)
+          @mixpanel.append_event("Sign up")
+
+          output.string.should include("[Mixpanel] [10/Oct/2009 13:55:36 UTC] Sign up with properties:")
+        end
       end
 
       it "should append events with properties" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,23 @@ end
 # Fakeweb
 FakeWeb.allow_net_connect = false
 FakeWeb.register_uri(:any, /http:\/\/api\.mixpanel\.com.*/, :body => "1")
+
+module SpecHelper
+  def self.stub_time_dot_now(desired_time)
+    Time.class_eval do
+      class << self
+        alias original_now now
+      end
+    end
+    (class << Time; self; end).class_eval do
+      define_method(:now) { desired_time }
+    end
+    yield
+  ensure
+    Time.class_eval do
+      class << self
+        alias now original_now
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi!

I was thinking that it maybe useful to have a way to enable logs for Mixpanel notifications.
I'm using this gem in a production project, and we have quite complex Mixpanel notifications logic.

Having these calls in log helps a lot! I hope that this would be useful for someone else.
