### PR TITLE
Fix for send_file returning 0 bytes #16

### DIFF
--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -17,9 +17,11 @@ module Mixpanel
 
         @status, @headers, @response = @app.call(env)
 
-        update_response!
-        update_content_length!
-        delete_event_queue!
+        if is_trackable_response?
+          update_response!
+          update_content_length!
+          delete_event_queue!
+        end
 
         [@status, @headers, @response]
       end
@@ -62,6 +64,10 @@ module Mixpanel
 
       def is_javascript_response?
         @headers["Content-Type"].include?("text/javascript") if @headers.has_key?("Content-Type")
+      end
+
+      def is_trackable_response?
+        is_html_response? || is_javascript_response?
       end
 
       def render_mixpanel_scripts


### PR DESCRIPTION
I've checked this worked on our servers, but couldn't get a failing test to commit. This was the best I could do, but it wouldn't fail even without the changes I made. Any ideas?

```
describe "With attachment responses" do
    before do
      setup_rack_application(DummyApp, :body => nil,
                             :headers => {"Content-Type" => "application/pdf", "Content-Length" => 123})
      get "/"
    end

    it "should leave the body untouched" do
      last_response.body.should == html_document
    end

    it "should not reset the content length" do
      last_response.headers["Content-Length"].should == "123"
    end
  end
```
