### PR TITLE
Proxy

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -57,6 +57,10 @@ To execute any javascript API call
   @mixpanel.append_api("register", {:some => "property"})
   @mixpanel.append_api("identify", "Unique Identifier")
 
+If you are proxying Mixpanel API requests then you can set a custom url and additionally stop the token from being sent by marking it as false if you're going to let the proxy add it...
+
+  @mixpanel = Mixpanel::Tracker.new(flase, request.env, true, 'http://localhost:8000/mixpanelproxy?data=')
+
 == Resque and Rails example
 
 If you don't want to use the built in Mixpanel Gem async feature bellow there is an example about how to make async calls using Resque.


### PR DESCRIPTION
I've added the option to send the base URI as a parameter and made the token optional (set to false to exclude), to support local proxying of Mixpanel API requests. In my use case the proxy routes events, adding the token when it sends on to Mixpanel, so I don't need it in the rails app.
