### PR TITLE
Update Mixpanel JS to version 2 API and add support for set_config options.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,3 +131,4 @@ All collaborations are welcome to this project, please fork and make a pull requ
 * {Brad Wilson}[https://github.com/bradx3]
 * {Mark Cheverton}[https://github.com/ennui2342]
 * {Jamie Quint}[https://github.com/jamiequint]
+* {Ryan Schmukler}[https://github.com/rschmukler]

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,14 +20,14 @@ Add this to your environment config file or create a new initializer for it...
 
   config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN"
 
-If you want to use the asynchronous version of Mixpanel's javascript API
-
-  config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :async => true
-
 By default the scripts are inserted into the head of the html response. If you'd prefer the scripts to run after all rendering has completed you can set the insert_js_last flag and they'll be added at the end of the body tag. This will work whether or not you opt for the aynchronous version of the API. However, when inserting js into an ajax response it will have no effect:
 
-  config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :async => true, :insert_js_last => true
+  config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :insert_js_last => true
 
+You can also pass Mixpanel configuration details as seen here (https://mixpanel.com/docs/integration-libraries/javascript-full-api#set_config):
+
+  config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", :config => {:debug => true}
+  
 In your application_controller class add a method to instance mixpanel.
 
   before_filter :initialize_mixpanel
@@ -112,3 +112,4 @@ All collaborations are welcome to this project, please fork and make a pull requ
 * {James Ferguson}[https://github.com/JamesFerguson]
 * {Brad Wilson}[https://github.com/bradx3]
 * {Mark Cheverton}[https://github.com/ennui2342]
+* {Jamie Quint}[https://github.com/jamiequint]

--- a/README.rdoc
+++ b/README.rdoc
@@ -86,6 +86,24 @@ If you don't want to use the built in Mixpanel Gem async feature bellow there is
      end
    end
 
+== Persistence
+
+If you would like, the Mixpanel gem may be configured to store its queue in a Rack session. This allows events to be stored through redirects, helpful if you sign in and redirect but want to associate an event with that action.
+
+The mixpanel gem will also remove duplicate events from your queue for information that should only be trasmitted to the API once, such as `mixpanel.identify`, `mixpanel.name_tag`, `mixpanel.people.set`, and `mixpanel.register`. This allows you to use a before filter to set these variables, redirect, and still have them only transmitted once.
+
+To enable persistence, you must set it in two places. Once when you initialize the middleware...
+
+    config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", persistence: true
+
+And once when you initialize a tracker:
+
+    before_filter :initialize_mixpanel
+
+    def initialize_mixpanel
+      @mixpanel = Mixpanel::Tracker.new("YOUR_MIXPANEL_API_TOKEN", request.env, true, true)
+    end
+
 == Notes
 
 There are two forms of async operation:

--- a/README.rdoc
+++ b/README.rdoc
@@ -94,7 +94,7 @@ The mixpanel gem will also remove duplicate events from your queue for informati
 
 To enable persistence, you must set it in two places. Once when you initialize the middleware...
 
-    config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", persistence: true
+    config.middleware.use "Mixpanel::Tracker::Middleware", "YOUR_MIXPANEL_API_TOKEN", persist: true
 
 And once when you initialize a tracker:
 

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -20,7 +20,7 @@ module Mixpanel
     
     def append_person_event(properties = {})
       # evaluate symbols and rewrite
-      special_properties = %w{email created_at}
+      special_properties = %w{email created}
       special_properties.each do |key|
         symbolized_key = key.to_sym
         if properties.has_key?(symbolized_key)

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -17,10 +17,10 @@ module Mixpanel
     def append_event(event, properties = {})
       append_api('track', event, properties)
     end
-    
+
     def append_person_event(properties = {})
       # evaluate symbols and rewrite
-      special_properties = %w{email created}
+      special_properties = %w{email created first_name last_name last_login}
       special_properties.each do |key|
         symbolized_key = key.to_sym
         if properties.has_key?(symbolized_key)

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -17,6 +17,19 @@ module Mixpanel
     def append_event(event, properties = {})
       append_api('track', event, properties)
     end
+    
+    def append_person_event(properties = {})
+      # evaluate symbols and rewrite
+      special_properties = %w{email created_at}
+      special_properties.each do |key|
+        symbolized_key = key.to_sym
+        if properties.has_key?(symbolized_key)
+          properties["$#{key}"] = properties[symbolized_key]
+          properties.delete(symbolized_key)
+        end
+      end
+      append_api('people.set', properties)
+    end
 
     def append_api(type, *args)
       queue << [type, args.map {|arg| arg.to_json}]

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -31,6 +31,10 @@ module Mixpanel
       append_api('people.set', properties)
     end
 
+    def append_person_increment_event(property, increment=1)
+      append_api('people.increment', property, increment)
+    end
+
     def append_api(type, *args)
       queue << [type, args.map {|arg| arg.to_json}]
     end

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -20,7 +20,7 @@ module Mixpanel
 
     def append_person_event(properties = {})
       # evaluate symbols and rewrite
-      special_properties = %w{email created first_name last_name last_login}
+      special_properties = %w{email created first_name last_name last_login username country_code}
       special_properties.each do |key|
         symbolized_key = key.to_sym
         if properties.has_key?(symbolized_key)

--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -1,4 +1,5 @@
 require 'rack'
+require 'json'
 
 module Mixpanel
   class Tracker
@@ -7,7 +8,8 @@ module Mixpanel
         @app = app
         @token = mixpanel_token
         @options = {
-          :insert_js_last => false
+          :insert_js_last => false,
+          :config => {}
         }.merge(options)
       end
 
@@ -83,6 +85,7 @@ module Mixpanel
               Array.prototype.slice.call(arguments,0)))}})(g[e]);c._i.push([a,d,f])};window.mixpanel=c}
               )(document,window.mixpanel||[]);
               mixpanel.init("#{@token}");
+              mixpanel.set_config(#{@options[:config].to_json});
         </script>
           EOT
       end

--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -74,10 +74,20 @@ module Mixpanel
       def render_mixpanel_scripts
         <<-EOT
           <!-- start Mixpanel -->
-          <script type="text/javascript">(function(c,b){var a,d,h,e;a=c.createElement("script");a.type="text/javascript";a.async=!0;a.src=("https:"===c.location.protocol?"https:":"http:")+'//api.mixpanel.com/site_media/js/api/mixpanel.2.js';d=c.getElementsByTagName("script")[0];d.parentNode.insertBefore(a,d);b._i=[];b.init=function(a,c,f){function d(a,b){var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(Array.prototype.slice.call(arguments,0)))}}var g=b;"undefined"!==typeof f?g=
-          b[f]=[]:f="mixpanel";g.people=g.people||[];h="disable track track_pageview track_links track_forms register register_once unregister identify name_tag set_config people.set people.increment".split(" ");for(e=0;e<h.length;e++)d(g,h[e]);b._i.push([a,c,f])};window.mixpanel=b})(document,window.mixpanel||[]);
-          mixpanel.init("#{@token}");
-          mixpanel.set_config(#{@options[:config].to_json});
+          <script type="text/javascript">
+            (function(c,a){var b,d,h,e;b=c.createElement("script");b.type="text/javascript";
+            b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
+            '//api.mixpanel.com/site_media/js/api/mixpanel.2.js';d=c.getElementsByTagName("script")[0];
+            d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
+            var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
+            Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
+            f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
+            'track_forms','register','register_once','unregister','identify','name_tag',
+            'set_config','people.set','people.increment'];for(e=0;e<h.length;e++)d(g,h[e]);
+            a._i.push([b,c,f])};a.__SV=1.1;window.mixpanel=a})(document,window.mixpanel||[]);
+
+            mixpanel.init("#{@token}");
+            mixpanel.set_config(#{@options[:config].to_json});
           </script>
           <!-- end Mixpanel -->
         EOT

--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -72,22 +72,15 @@ module Mixpanel
       end
 
       def render_mixpanel_scripts
-          <<-EOT
-        <script type='text/javascript'>
-          (function(d,c){var a,b,g,e;a=d.createElement("script");a.type="text/javascript";
-              a.async=!0;a.src=("https:"===d.location.protocol?"https:":"http:")+
-              '//api.mixpanel.com/site_media/js/api/mixpanel.2.js';b=d.getElementsByTagName("script")[0];
-              b.parentNode.insertBefore(a,b);c._i=[];c.init=function(a,d,f){var b=c;
-              "undefined"!==typeof f?b=c[f]=[]:f="mixpanel";g=['disable','track','track_pageview',
-              'track_links','track_forms','register','register_once','unregister','identify',
-              'name_tag','set_config'];
-              for(e=0;e<g.length;e++)(function(a){b[a]=function(){b.push([a].concat(
-              Array.prototype.slice.call(arguments,0)))}})(g[e]);c._i.push([a,d,f])};window.mixpanel=c}
-              )(document,window.mixpanel||[]);
-              mixpanel.init("#{@token}");
-              mixpanel.set_config(#{@options[:config].to_json});
-        </script>
-          EOT
+        <<-EOT
+          <!-- start Mixpanel -->
+          <script type="text/javascript">(function(c,b){var a,d,h,e;a=c.createElement("script");a.type="text/javascript";a.async=!0;a.src=("https:"===c.location.protocol?"https:":"http:")+'//api.mixpanel.com/site_media/js/api/mixpanel.2.js';d=c.getElementsByTagName("script")[0];d.parentNode.insertBefore(a,d);b._i=[];b.init=function(a,c,f){function d(a,b){var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(Array.prototype.slice.call(arguments,0)))}}var g=b;"undefined"!==typeof f?g=
+          b[f]=[]:f="mixpanel";g.people=g.people||[];h="disable track track_pageview track_links track_forms register register_once unregister identify name_tag set_config people.set people.increment".split(" ");for(e=0;e<h.length;e++)d(g,h[e]);b._i.push([a,c,f])};window.mixpanel=b})(document,window.mixpanel||[]);
+          mixpanel.init("#{@token}");
+          mixpanel.set_config(#{@options[:config].to_json});
+          </script>
+          <!-- end Mixpanel -->
+        EOT
       end
 
       def delete_event_queue!

--- a/spec/mixpanel/tracker/middleware_spec.rb
+++ b/spec/mixpanel/tracker/middleware_spec.rb
@@ -17,7 +17,7 @@ describe Mixpanel::Tracker::Middleware do
   describe "Appending async mixpanel scripts" do
     describe "With ajax requests" do
       before do
-        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}})
         get "/", {}, {"HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
       end
 
@@ -32,7 +32,7 @@ describe Mixpanel::Tracker::Middleware do
 
     describe "With large ajax response" do
       before do
-        setup_rack_application(DummyApp, {:body => large_script, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        setup_rack_application(DummyApp, {:body => large_script, :headers => {"Content-Type" => "text/html"}})
         get "/", {}, {"HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
       end
 
@@ -48,7 +48,7 @@ describe Mixpanel::Tracker::Middleware do
     describe "With regular requests" do
       describe "With js in head" do
         before do
-          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true, :insert_js_last => false})
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:insert_js_last => false})
           get "/"
         end
 
@@ -62,7 +62,7 @@ describe Mixpanel::Tracker::Middleware do
         end
 
         it "should use the specified token instantiating mixpanel lib" do
-          last_response.should =~ /mpq.push\(\["init", "#{MIX_PANEL_TOKEN}"\]\)/
+          last_response.body.should =~ /mixpanel\.init\("#{MIX_PANEL_TOKEN}"\)/ 
         end
 
         it "should define Content-Length if not exist" do
@@ -76,7 +76,7 @@ describe Mixpanel::Tracker::Middleware do
 
       describe "With js last" do
         before do
-          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true, :insert_js_last => true})
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:insert_js_last => true})
           get "/"
         end
 
@@ -131,12 +131,12 @@ describe Mixpanel::Tracker::Middleware do
           Nokogiri::HTML(last_response.body).search('body script').should be_empty
         end
 
-        it "should have 2 included scripts" do
-          Nokogiri::HTML(last_response.body).search('script').size.should == 2
+        it "should have 1 included script" do
+          Nokogiri::HTML(last_response.body).search('script').size.should == 1
         end
 
         it "should use the specified token instantiating mixpanel lib" do
-          last_response.should =~ /new MixpanelLib\('#{MIX_PANEL_TOKEN}'\)/
+          last_response.body.should =~ /mixpanel\.init\("#{MIX_PANEL_TOKEN}"\)/          
         end
 
         it "should define Content-Length if not exist" do
@@ -171,7 +171,7 @@ describe Mixpanel::Tracker::Middleware do
 
     describe "With ajax requests and text/html response" do
       before do
-        setup_rack_application(DummyApp, {:body => "<p>response</p>", :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        setup_rack_application(DummyApp, {:body => "<p>response</p>", :headers => {"Content-Type" => "text/html"}})
 
         get "/", {}, {"mixpanel_events" => @mixpanel.queue, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
       end
@@ -182,9 +182,8 @@ describe Mixpanel::Tracker::Middleware do
 
       it "should be tracking the correct events inside a script tag" do
         script = Nokogiri::HTML(last_response.body).search('script')
-        script.inner_html.should =~ /try\s?\{(.*)\}\s?catch/m
-        script.inner_html.should =~ /mpq\.push\(\["track",\s?"Visit",\s?\{"article":1\}\]\)/
-        script.inner_html.should =~ /mpq\.push\(\["track",\s?"Sign in",\s?\{\}\]\)/
+        script.inner_html.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+        script.inner_html.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
       end
 
       it "should delete events queue after use it" do
@@ -194,7 +193,7 @@ describe Mixpanel::Tracker::Middleware do
 
     describe "With ajax requests and text/javascript response" do
       before do
-        setup_rack_application(DummyApp, {:body => "alert('response')", :headers => {"Content-Type" => "text/javascript"}}, {:async => true})
+        setup_rack_application(DummyApp, {:body => "alert('response')", :headers => {"Content-Type" => "text/javascript"}})
         get "/", {}, {"mixpanel_events" => @mixpanel.queue, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"}
       end
 
@@ -204,8 +203,8 @@ describe Mixpanel::Tracker::Middleware do
 
       it "should be tracking the correct events inside a try/catch" do
         script = last_response.body.match(/try\s?\{(.*)\}\s?catch/m)[1]
-        script.should =~ /mpq\.push\(\["track",\s?"Visit",\s?\{"article":1\}\]\)/
-        script.should =~ /mpq\.push\(\["track",\s?"Sign in",\s?\{\}\]\)/
+        script.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+        script.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
       end
 
       it "should delete events queue after use it" do
@@ -215,7 +214,7 @@ describe Mixpanel::Tracker::Middleware do
 
     describe "With regular requests" do
       before do
-        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:async => true})
+        setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}})
 
         get "/", {}, {"mixpanel_events" => @mixpanel.queue}
       end
@@ -225,8 +224,8 @@ describe Mixpanel::Tracker::Middleware do
       end
 
       it "should be tracking the correct events" do
-        last_response.body.should =~ /mpq\.push\(\["track",\s?"Visit",\s?\{"article":1\}\]\)/
-        last_response.body.should =~ /mpq\.push\(\["track",\s?"Sign in",\s?\{\}\]\)/
+        last_response.body.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+        last_response.body.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
       end
 
       it "should delete events queue after use it" do
@@ -256,8 +255,8 @@ describe Mixpanel::Tracker::Middleware do
       it "should be tracking the correct events inside a script tag" do
         script = Nokogiri::HTML(last_response.body).search('script')
         script.inner_html.should =~ /try\s?\{(.*)\}\s?catch/m
-        script.inner_html.should =~ /mpmetrics\.track\("Visit",\s?\{"article":1\}\)/
-        script.inner_html.should =~ /mpmetrics\.track\("Sign in",\s?\{\}\)/
+        script.inner_html.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+        script.inner_html.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
       end
 
       it "should delete events queue after use it" do
@@ -277,8 +276,8 @@ describe Mixpanel::Tracker::Middleware do
 
       it "should be tracking the correct events inside a try/catch" do
         script = last_response.body.match(/try\s?\{(.*)\}\s?catch/m)[1]
-        script.should =~ /mpmetrics\.track\("Visit",\s?\{"article":1\}\)/
-        script.should =~ /mpmetrics\.track\("Sign in",\s?\{\}\)/
+        script.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+        script.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
       end
 
       it "should delete events queue after use it" do
@@ -293,13 +292,13 @@ describe Mixpanel::Tracker::Middleware do
         get "/", {}, {"mixpanel_events" => @mixpanel.queue}
       end
 
-      it "should render 3 script tags" do
-        Nokogiri::HTML(last_response.body).search('script').size.should == 3
+      it "should render 2 script tags" do
+        Nokogiri::HTML(last_response.body).search('script').size.should == 2
       end
 
       it "should be tracking the correct events" do
-        last_response.body.should =~ /mpmetrics\.track\("Visit",\s?\{"article":1\}\)/
-        last_response.body.should =~ /mpmetrics\.track\("Sign in",\s?\{\}\)/
+        last_response.body.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+        last_response.body.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
       end
 
       it "should delete events queue after use it" do

--- a/spec/mixpanel/tracker/middleware_spec.rb
+++ b/spec/mixpanel/tracker/middleware_spec.rb
@@ -235,8 +235,6 @@ describe Mixpanel::Tracker::Middleware do
       end
 
       it "should be tracking the correct events" do
-        puts last_response.body
-
         check_for_default_appends_on last_response.body
       end
 

--- a/spec/mixpanel/tracker/middleware_spec.rb
+++ b/spec/mixpanel/tracker/middleware_spec.rb
@@ -194,8 +194,6 @@ describe Mixpanel::Tracker::Middleware do
       end
 
       it "should be tracking the correct events inside a script tag" do
-        puts last_response.body
-
         script = Nokogiri::HTML(last_response.body).search('script')
         check_for_default_appends_on script.inner_html
       end

--- a/spec/mixpanel/tracker/middleware_spec.rb
+++ b/spec/mixpanel/tracker/middleware_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+def exec_default_appends_on(mixpanel)
+  mixpanel.append_event("Visit", {:article => 1})
+  mixpanel.append_event("Sign in")
+  mixpanel.append_person_event(:first_name => "foo", :last_name => "bar", :username => "foobar")
+  mixpanel.append_person_increment_event(:sign_in_rate)
+end
+
+def check_for_default_appends_on(txt)
+  txt.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
+  txt.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+  txt.should =~ /mixpanel\.people\.set\(\{(?=.*\"username\"\s?:\s?\"foobar\")(?=.*\"\$first_name\"\s?:\s?\"foo\")(?=.*\"\$last_name\"\s?:\s?\"bar\")[^}]*\}\)/
+  txt.should =~ /mixpanel\.people\.increment\(\"sign_in_rate\"\s?,\s?1\)/
+end
+
 describe Mixpanel::Tracker::Middleware do
   include Rack::Test::Methods
 
@@ -62,7 +76,7 @@ describe Mixpanel::Tracker::Middleware do
         end
 
         it "should use the specified token instantiating mixpanel lib" do
-          last_response.body.should =~ /mixpanel\.init\("#{MIX_PANEL_TOKEN}"\)/ 
+          last_response.body.should =~ /mixpanel\.init\("#{MIX_PANEL_TOKEN}"\)/
         end
 
         it "should define Content-Length if not exist" do
@@ -136,7 +150,7 @@ describe Mixpanel::Tracker::Middleware do
         end
 
         it "should use the specified token instantiating mixpanel lib" do
-          last_response.body.should =~ /mixpanel\.init\("#{MIX_PANEL_TOKEN}"\)/          
+          last_response.body.should =~ /mixpanel\.init\("#{MIX_PANEL_TOKEN}"\)/
         end
 
         it "should define Content-Length if not exist" do
@@ -165,8 +179,7 @@ describe Mixpanel::Tracker::Middleware do
   describe "Tracking async appended events" do
     before do
       @mixpanel = Mixpanel::Tracker.new(MIX_PANEL_TOKEN, {})
-      @mixpanel.append_event("Visit", {:article => 1})
-      @mixpanel.append_event("Sign in")
+      exec_default_appends_on @mixpanel
     end
 
     describe "With ajax requests and text/html response" do
@@ -181,9 +194,10 @@ describe Mixpanel::Tracker::Middleware do
       end
 
       it "should be tracking the correct events inside a script tag" do
+        puts last_response.body
+
         script = Nokogiri::HTML(last_response.body).search('script')
-        script.inner_html.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
-        script.inner_html.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+        check_for_default_appends_on script.inner_html
       end
 
       it "should delete events queue after use it" do
@@ -203,8 +217,7 @@ describe Mixpanel::Tracker::Middleware do
 
       it "should be tracking the correct events inside a try/catch" do
         script = last_response.body.match(/try\s?\{(.*)\}\s?catch/m)[1]
-        script.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
-        script.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+        check_for_default_appends_on script
       end
 
       it "should delete events queue after use it" do
@@ -224,8 +237,9 @@ describe Mixpanel::Tracker::Middleware do
       end
 
       it "should be tracking the correct events" do
-        last_response.body.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
-        last_response.body.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+        puts last_response.body
+
+        check_for_default_appends_on last_response.body
       end
 
       it "should delete events queue after use it" do
@@ -237,8 +251,7 @@ describe Mixpanel::Tracker::Middleware do
   describe "Tracking appended events" do
     before do
       @mixpanel = Mixpanel::Tracker.new(MIX_PANEL_TOKEN, {})
-      @mixpanel.append_event("Visit", {:article => 1})
-      @mixpanel.append_event("Sign in")
+      exec_default_appends_on @mixpanel
     end
 
     describe "With ajax requests and text/html response" do
@@ -254,9 +267,7 @@ describe Mixpanel::Tracker::Middleware do
 
       it "should be tracking the correct events inside a script tag" do
         script = Nokogiri::HTML(last_response.body).search('script')
-        script.inner_html.should =~ /try\s?\{(.*)\}\s?catch/m
-        script.inner_html.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
-        script.inner_html.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+        check_for_default_appends_on script.inner_html
       end
 
       it "should delete events queue after use it" do
@@ -276,8 +287,7 @@ describe Mixpanel::Tracker::Middleware do
 
       it "should be tracking the correct events inside a try/catch" do
         script = last_response.body.match(/try\s?\{(.*)\}\s?catch/m)[1]
-        script.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
-        script.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+        check_for_default_appends_on script
       end
 
       it "should delete events queue after use it" do
@@ -297,8 +307,7 @@ describe Mixpanel::Tracker::Middleware do
       end
 
       it "should be tracking the correct events" do
-        last_response.body.should =~ /mixpanel\.track\("Visit",\s?\{"article":1\}\)/
-        last_response.body.should =~ /mixpanel\.track\("Sign in",\s?\{\}\)/
+        check_for_default_appends_on last_response.body
       end
 
       it "should delete events queue after use it" do


### PR DESCRIPTION
All API requests with the new JS code are asynchronous so just removed that option for JS based requests (although should just be ignored if the option is there so this should remain backwards compatible)
