### PR TITLE
Fixed README Tracker Initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Where **options** is a Hash that accepts the following keys:
 ### Initialize Mixpanel class
 
 ```ruby
-  @mixpanel = Mixpanel::Tracker.new("YOUR_MIXPANEL_API_TOKEN", request.env, true, options)
+  @mixpanel = Mixpanel::Tracker.new("YOUR_MIXPANEL_API_TOKEN", request.env, options)
 ```
 Where **options** is a Hash that accepts the following keys:
 


### PR DESCRIPTION
Documentation was passing in true (used previously for the async option) during Tracker initialization. It should now be an options hash for a total of 3 arguments instead of 4.
