### PR TITLE
Allow for passing distinct_id with track_event

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ Where **options** is a Hash that accepts the following keys:
   once.
   *To enable persistence*, you must set it in both places, Middleware and when you initialize Mixpanel class.
 
+* **distinct_id** : String
+
+  *Default: nil*.
+  Mixpanel may be provided with a 'distinct_id' value in order to tie events to a particular user. If this is
+  provided, each track_event request will automatically include the 'distict_id' value. This would typically
+  be the same identifier used on the front-end.
+
+  Example:
+
+```ruby
+  @mixpanel = Mixpanel::Tracker.new("TOKEN", request.env, {:distinct_id => "Unique Identifier"})
+  @mixpanel.append_api("identify", "Unique Identifier")
+  @mixpanel.track_event("Some Event") # Will now be tied to the user
+```
+
 ### Track events directly.
 
 ```ruby

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -6,11 +6,14 @@ require 'mixpanel/tracker/middleware'
 
 module Mixpanel
   class Tracker
+    attr_accessor :distinct_id
+
     def initialize(token, env, options={})
       @token = token
       @env = env
       @async = options.fetch(:async, false)
       @url = options.fetch(:url, 'http://api.mixpanel.com/track/?data=')
+      @distinct_id = options.fetch(:distinct_id, nil)
       @persist = options.fetch(:persist, false)
 
       if @persist
@@ -48,6 +51,7 @@ module Mixpanel
     def track_event(event, properties = {})
       options = { :time => Time.now.utc.to_i, :ip => ip }
       options.merge!( :token => @token ) if @token
+      options.merge!( :distinct_id => @distinct_id ) if @distinct_id
       options.merge!(properties)
       params = build_event(event, options)
       parse_response request(params)

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -41,6 +41,30 @@ describe Mixpanel::Tracker do
         @mixpanel.should_receive(:request).with(params).and_return("1")
         @mixpanel.track_event("Sign up")
       end
+
+      it "should call request method with distinct_id if available" do
+        opts = { :distinct_id => "MisterClicky" }
+        @mixpanel = Mixpanel::Tracker.new(MIX_PANEL_TOKEN, @env = {"HTTP_X_FORWARDED_FOR" => "127.0.0.1"}, opts)
+
+        params = {:event => "ClickClick", :properties =>
+          {:token => MIX_PANEL_TOKEN, :time => Time.now.utc.to_i, :ip => '127.0.0.1', :distinct_id => "MisterClicky"}
+        }
+
+        @mixpanel.should_receive(:request).with(params).and_return("1")
+        @mixpanel.track_event("ClickClick")
+      end
+
+      it "should allow for setting of disctinct_id after initialization" do
+        @mixpanel = Mixpanel::Tracker.new(MIX_PANEL_TOKEN, @env = {"HTTP_X_FORWARDED_FOR" => "127.0.0.1"})
+
+        params = {:event => "ClickClick", :properties =>
+          {:token => MIX_PANEL_TOKEN, :time => Time.now.utc.to_i, :ip => '127.0.0.1', :distinct_id => "MisterClicky"}
+        }
+
+        @mixpanel.distinct_id = 'MisterClicky'
+        @mixpanel.should_receive(:request).with(params).and_return("1")
+        @mixpanel.track_event("ClickClick")
+      end
     end
   end
 


### PR DESCRIPTION
Mixpanel allows for the passing of a distinct_id with each event. On the
backend this must be passed with each request.

This adds the ability to pass in a distinct id on initialization, or
later on when it become available
