### PR TITLE
Update mixpanel script to 2.1

### DIFF
--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -80,13 +80,13 @@ module Mixpanel
           <script type="text/javascript">
             (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
             b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-            '//cdn.mxpnl.com/libs/mixpanel-2.0.min.js';d=c.getElementsByTagName("script")[0];
+            '//cdn.mxpnl.com/libs/mixpanel-2.1.min.js';d=c.getElementsByTagName("script")[0];
             d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
             var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
             Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
             f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
             'track_forms','register','register_once','unregister','identify','name_tag',
-            'set_config','people.set','people.increment'];for(e=0;e<h.length;e++)d(g,h[e]);
+            'set_config','people.identify','people.set','people.increment'];for(e=0;e<h.length;e++)d(g,h[e]);
             a._i.push([b,c,f])};a.__SV=1.1;})(document,window.mixpanel||[]);
 
             mixpanel.init("#{@token}");


### PR DESCRIPTION
Updates the version of the Mixpanel script to 2.1 from 2.0 (2.1 is now
shown in the recommended setup) and adds 'people.identify' to the list
of identified commands.
