### PR TITLE
Test your mixpanel integration!

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Where **options** is a Hash that accepts the following keys:
   once.
   *To enable persistence*, you must set it in both places, Middleware and when you initialize Mixpanel class.
 
+* **test_service_hostname** : Where to find a running instance of the <a href="https://github.com/johncant/mixpanel_test_service">mixpanel_test_service</a>, i.e. "localhost:3001". If defined, the mixpanel javascript API is hijacked to post all mixpanel events to the running mixpanel_test_service
+
 * **config** : a Hash
 
   *Default: {}*.

--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -10,6 +10,7 @@ module Mixpanel
         @options = {
           :insert_js_last => false,
           :persist => false,
+          :test_service_hostname => nil,
           :config => {}
         }.merge(options)
       end
@@ -80,7 +81,7 @@ module Mixpanel
           <script type="text/javascript">
             (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
             b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-            '//cdn.mxpnl.com/libs/mixpanel-2.0.min.js';d=c.getElementsByTagName("script")[0];
+            '//#{@options[:test_service_hostname]||"cdn.mxpnl.com"}/libs/mixpanel-2.0.min.js';d=c.getElementsByTagName("script")[0];
             d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
             var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
             Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:


### PR DESCRIPTION
Hi all,

I've written a <a href="https://github.com/johncant/mixpanel_test_service">gem for testing mixpanel integration</a> using a fake mixpanel server which you can access from ruby and <a href="https://github.com/johncant/mixpanel_test-rails">a gem that makes it work with cucumber and provides step definitions</a> (feel free to add other types of rails test helpers to it).

This pull request adds a middleware configuration option which changes all the Mixpanel API requests to get made to a test server rather than the real Mixpanel API.

Hope you like it!

John
