### PR TITLE
Request-specific filtering

### DIFF
--- a/lib/mixpanel/tracker/middleware.rb
+++ b/lib/mixpanel/tracker/middleware.rb
@@ -18,7 +18,7 @@ module Mixpanel
         @env = env
 
         @status, @headers, @response = @app.call(env)
-
+        
         if is_trackable_response?
           merge_queue! if @options[:persist]
           update_response!
@@ -71,6 +71,7 @@ module Mixpanel
 
       def is_trackable_response?
         return false if @status == 302
+        return false if @env.has_key?("HTTP_SKIP_MIXPANEL_MIDDLEWARE")
         is_html_response? || is_javascript_response?
       end
 

--- a/spec/mixpanel/tracker/middleware_spec.rb
+++ b/spec/mixpanel/tracker/middleware_spec.rb
@@ -31,7 +31,23 @@ describe Mixpanel::Tracker::Middleware do
       last_response.body.should == html_document
     end
   end
-
+  
+  describe "Dummy app, handles skip requests properly" do
+    before do
+      setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}})
+    end
+    
+    it "should not append mixpanel scripts with skip request" do
+      get "/", {}, {"HTTP_SKIP_MIXPANEL_MIDDLEWARE" => true}
+      Nokogiri::HTML(last_response.body).search('script').should be_empty
+    end
+    
+    it "should append mixpanel scripts without skip request" do
+      get "/"
+      Nokogiri::HTML(last_response.body).search('script').size.should == 1
+    end
+  end
+    
   describe "Appending async mixpanel scripts" do
     describe "With ajax requests" do
       before do


### PR DESCRIPTION
Occasionally I need to return HTML to the browser to be displayed. That HTML doesn't need these filters applied as they are already on the page. I think adding something to the app controllers would be more robust here, but sending a header up with the AJAX request to prevent the filter works for now.
