### PR TITLE
Adding engage endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Where **options** is a Hash that accepts the following keys:
 
 * **url** : String
  
-  *Default: http://api.mixpanel.com/track/?data=*.
+  *Default: http://api.mixpanel.com*.
   If you are proxying Mixpanel API requests then you can set a custom url and additionally stop the token from
   being sent by marking it as false if you're going to let the proxy add it.
-  Example: { url: "http://localhost:8000/mixpanelproxy?data=" }.
+  Example: { url: "http://localhost:8000/mixpanelproxy" }.
 
 * **persist** : true | false
 
@@ -115,6 +115,13 @@ Where **options** is a Hash that accepts the following keys:
 
 ```ruby
   @mixpanel.track_event("Sign in", {:some => "property"})
+```
+
+### Interface with People management directly
+
+```ruby
+  @mixpanel.engage_set(@user.id, {:username => @user.username, :email => @user.email})
+  @mixpanel.engage_add(@user.id, {:monkeys_punched => 12})
 ```
 
 ### Append events to be tracked with Javascript.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'nokogiri'
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
 
 MIX_PANEL_TOKEN = "e2d8b0bea559147844ffab3d607d26a6"
-
+DISTINCT_ID     = "abcd1234"
 
 def mixpanel_queue_should_include(mixpanel, type, *arguments)
   mixpanel.queue.each do |event_type, event_arguments|


### PR DESCRIPTION
So now it's possible to manage people via /engage endpoint. I added `engage_set` and `engage_add` methods, also the generic `engage` one to keep things dry.

Looks like this:

``` ruby
  @mixpanel.engage_set(@user.id, {:username => @user.username, :email => @user.email})
  @mixpanel.engage_add(@user.id, {:monkeys_punched => 12})
```

I reshuffled some code inside tracker.rb. The only adjustment I needed to do is remove endpoints from @url attribute as I wanted to reuse initialized @mixpanel tracker. Otherwise you need to spin up a separate one if yo want to track events and people.

Moved special person properties parser into it's own method. It won't mutate passed in hash either. Wanted to do similar thing for event tracking, but can't find any documentation. I know `$signup` is a thing, can't find others.

Added all necessary tests.
