### PR TITLE
Pixel Based Event Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,16 @@ Example:
 ### Pixel Based Event Tracking
 
 ```ruby
-  image_tag @mixpanel.tracking_pixel("Opened Email", { :distinct_id => "bob@email.com", :campaign => "Retarget"}), :width => 1, :height => 1
+@mixpanel.tracking_pixel "Opened Email", { :distinct_id => "bob@email.com", :campaign => "Retarget" }
 ```
 
 This allows to track events just by loading a pixel. It's usually useful for tracking opened emails.
 You've got to specify your own `distinct_id` as it won't be able to retrieve it from cookies.
+
+And you can use it in your views with an image_tag helper:
+```ruby
+image_tag @mixpanel.tracking_pixel("Opened Email", { :distinct_id => "bob@email.com", :campaign => "Retarget" }), :width => 1, :height => 1
+```
 
 
 Mixpanel docs: https://mixpanel.com/docs/api-documentation/pixel-based-event-tracking

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Usage] (#usage)
   - [Initialize Mixpanel] (#initialize-mixpanel)
 	- [Track Events Directly](#track-events-directly)
+	- [Pixel Based Event Tracking](#pixel-based-event-tracking)
 	- [Import Events](#import-events)
 	- [Set Person Attributes Directly](#set-person-attributes-directly)
 	- [Increment Person Attributes Directly](#increment-person-attributes-directly)
@@ -187,6 +188,20 @@ Example:
 ```ruby
 @mixpanel.track 'Purchased credits', { :number => 5, 'First Time Buyer' => true }
 ```
+
+### Pixel Based Event Tracking
+
+```ruby
+  image_tag @mixpanel.tracking_pixel("Opened Email", { :distinct_id => "bob@email.com", :campaign => "Retarget"}), :width => 1, :height => 1
+```
+
+This allows to track events just by loading a pixel. It's usually useful for tracking opened emails.
+You've got to specify your own `distinct_id` as it won't be able to retrieve it from cookies.
+
+
+Mixpanel docs: https://mixpanel.com/docs/api-documentation/pixel-based-event-tracking
+
+
 
 ### Import Events
 

--- a/lib/mixpanel/event.rb
+++ b/lib/mixpanel/event.rb
@@ -6,6 +6,10 @@ module Mixpanel::Event
   def track(event, properties={}, options={})
     track_event event, properties, options, TRACK_URL
   end
+
+  def tracking_pixel(event, properties={}, options={})
+    build_url event, properties, options.merge(:url => TRACK_URL, :img => true)
+  end
   
   def import(event, properties={}, options={})
     track_event event, properties, options, IMPORT_URL
@@ -19,9 +23,7 @@ module Mixpanel::Event
   
   def track_event(event, properties, options, default_url)
     options.reverse_merge! :url => default_url, :async => @async, :api_key => @api_key
-    data = build_event event, track_properties(properties)
-    url = "#{options[:url]}?data=#{encoded_data(data)}"
-    url += "&api_key=#{options[:api_key]}" if options[:api_key].present?
+    url = build_url event, properties, options
     parse_response request(url, options[:async])
   end
   
@@ -37,5 +39,13 @@ module Mixpanel::Event
   
   def build_event(event, properties)
     { :event => event, :properties => properties_hash(properties, EVENT_PROPERTIES) }
+  end
+
+  def build_url event, properties, options
+    data = build_event event, track_properties(properties)
+    url = "#{options[:url]}?data=#{encoded_data(data)}"
+    url << "&api_key=#{options[:api_key]}" if options[:api_key].present?
+    url << "&img=1" if options[:img]
+    url
   end
 end

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -30,6 +30,16 @@ describe Mixpanel::Tracker do
         @mixpanel.track('Sign up', { :likeable => true }, { :api_key => 'asdf' }).should == true
       end
     end
+
+    context "Tracking pixel" do
+      it "should return a URL" do
+        @mixpanel.tracking_pixel("Sign up").should be_a(String)
+      end
+
+      it "should include img=1" do
+        @mixpanel.tracking_pixel("Sign up").should match(/&img=1/)
+      end
+    end
     
     context "Importing events" do
       it "should import simple events" do


### PR DESCRIPTION
Added `tracking_pixel` method to generate a URL for pixel based event tracking. Updated README accordingly.

Mixpanel Docs: https://mixpanel.com/docs/api-documentation/pixel-based-event-tracking
