### PR TITLE
People sets ip from env and allows setting of request properties, fixes issue 59

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ it will automatically be converted to the correct form (e.g., `{ :first_name => 
 	
 	This can be used to proxy Mixpanel API requests
 
-Example:
+Example using `distinct_id` to identify the user:
 
 ```ruby
 @mixpanel.set 'john-doe', { :age => 31, :email => 'john@doe.com' }
@@ -258,7 +258,7 @@ Example:
 
 Example using request properties, telling mixpanel to [ignore the time](https://groups.google.com/forum/#!msg/mp-dev/Ao4f8D0IKms/6MVhQqFDzL8J):
 
-``ruby
+```ruby
 @mixpanel.set { :distinct_id => 'john-doe', :ignore_time => true }, { :age => 31, :email => 'john@doe.com' }
 ```
 

--- a/README.md
+++ b/README.md
@@ -226,10 +226,13 @@ Example:
 ### Set Person Attributes Directly
 
 ```ruby
-@mixpanel.set distinct_id, properties, options
+@mixpanel.set distinct_id_or_request_properties, properties, options
 ```
 
-**distinct_id** is whatever is used to identify the user to Mixpanel.
+**distinct_id_or_request_properties** is whatever is used to identify the user to Mixpanel or a hash of
+properties of the [engage event](https://mixpanel.com/docs/people-analytics/people-http-specification-insert-data) that exist
+outside of the `$set`. Special properties will be automatically converted to the correct form (e.g., `{ :ip => '127.0.0.1' }` will be
+converted to `{ :$ip => '127.0.0.1' }`
 
 **properties** is a hash of properties to be set. The keys in the properties can either be strings
 or symbols.  If you send in a key that matches a [special property](https://mixpanel.com/docs/people-analytics/special-properties),
@@ -251,6 +254,12 @@ Example:
 
 ```ruby
 @mixpanel.set 'john-doe', { :age => 31, :email => 'john@doe.com' }
+```
+
+Example using request properties, telling mixpanel to [ignore the time](https://groups.google.com/forum/#!msg/mp-dev/Ao4f8D0IKms/6MVhQqFDzL8J):
+
+``ruby
+@mixpanel.set { :distinct_id => 'john-doe', :ignore_time => true }, { :age => 31, :email => 'john@doe.com' }
 ```
 
 ### Increment Person Attributes Directly

--- a/lib/mixpanel/event.rb
+++ b/lib/mixpanel/event.rb
@@ -27,10 +27,6 @@ module Mixpanel::Event
     parse_response request(url, options[:async])
   end
 
-  def ip
-    (@env['HTTP_X_FORWARDED_FOR'] || @env['REMOTE_ADDR'] || '').split(',').last
-  end
-
   def track_properties(properties, include_token=true)
     default = {:time => Time.now, :ip => ip}
     properties = default.merge(properties)

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -1,6 +1,6 @@
 module Mixpanel::Person
   PERSON_PROPERTIES = %w{email created first_name last_name name last_login username country_code}
-  PERSON_REQUEST_PROPERTIES = %w{token distinct_id ip}
+  PERSON_REQUEST_PROPERTIES = %w{token distinct_id ip ignore_time}
   PERSON_URL = 'http://api.mixpanel.com/engage/'
 
   def set(distinct_id, properties={}, options={})

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -39,6 +39,10 @@ module Mixpanel
 
     protected
 
+    def ip
+        (@env['HTTP_X_FORWARDED_FOR'] || @env['REMOTE_ADDR'] || '').split(',').last
+    end
+
     # Walk through each property and see if it is in the special_properties.  If so, change the key to have a $ in front of it.
     def properties_hash(properties, special_properties)
       properties.inject({}) do |props, (key, value)|

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -25,7 +25,7 @@ describe Mixpanel::Tracker do
       it "should track simple events" do
         @mixpanel.track("Sign up").should == true
       end
-      
+
       it "should track events with properties" do
         @mixpanel.track('Sign up', { :likeable => true }, { :api_key => 'asdf' }).should == true
       end
@@ -40,22 +40,26 @@ describe Mixpanel::Tracker do
         @mixpanel.tracking_pixel("Sign up").should match(/&img=1/)
       end
     end
-    
+
     context "Importing events" do
       it "should import simple events" do
         @mixpanel.import('Sign up').should == true
       end
-      
+
       it "should import events with properties" do
         @mixpanel.import('Sign up', { :likeable => true }, { :api_key => 'asdf' }).should == true
       end
     end
-    
+
     context "Engaging people" do
       it "should set attributes" do
         @mixpanel.set('person-a', { :email => 'me@domain.com', :likeable => false }).should == true
       end
-      
+
+      it "should set attributes with request properties" do
+        @mixpanel.set({ :distinct_id => 'person-a', :ignore_time => true },  { :email => 'me@domain.com', :likeable => false }).should == true
+      end
+
       it "should increment attributes" do
         @mixpanel.increment('person-a', { :tokens => 3, :money => -1 }).should == true
       end


### PR DESCRIPTION
Sets the geolocation ip automatically based on the provided env.

For those who won't necessarily have a sane env around, I've also updated it so you can set the geolocation ip by doing:

``` ruby
mixpanel.set {:distinct_id => "...", :ip => "127.0.0.1"}, {:status => "spiffy"}
```

This change is backward compatible - simply providing a distinct_id as the first argument will still work. This change does not apply to append_ series of methods because those will automatically use the javascript behavior.
