### PR TITLE
Fix for Issue #59 for location tracking based on $ip parameter

### DIFF
--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -42,7 +42,8 @@ module Mixpanel::Person
   end
 
   def build_person(action, distinct_id, properties, options = {})
-    special_properties = options.select{|x| x.to_s.start_with? "$" }
-    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), {:$token => @token, :$distinct_id => distinct_id}.merge(special_properties) }
+    special_properties = options.select{ |x| x.to_s.start_with? "$" }
+    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), 
+      :$token => @token, :$distinct_id => distinct_id }.merge(special_properties)
   end
 end

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -36,12 +36,13 @@ module Mixpanel::Person
     default  =  {:async => @async, :url => PERSON_URL}
     options = default.merge(options)
 
-    data = build_person action, distinct_id, properties
+    data = build_person action, distinct_id, properties, options
     url = "#{options[:url]}?data=#{encoded_data(data)}"
     parse_response request(url, options[:async])
   end
 
-  def build_person(action, distinct_id, properties)
-    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), :$token => @token, :$distinct_id => distinct_id }
+  def build_person(action, distinct_id, properties, options = {})
+    special_properties = options.select{|x| x.to_s.start_with? "$" }
+    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), {:$token => @token, :$distinct_id => distinct_id}.merge(special_properties) }
   end
 end


### PR DESCRIPTION
Hey @zevarito! 

These commits solve the location tracking issue described in Issue #59. 

It's a proposed implementation, with no additional tests. I just want to see what you think about it. 

I've tested it locally and in production and it works. 

It allows you to do this:

```
tracker = Mixpanel::Tracker.new MIXPANEL_API_KEY
tracker.set("12345", {:first_name => "John", :last_name => "Doe" }, { "$ip".to_sym => "186.137.140.183" } )
```

Thoughts? 

I'd appreciate any comments on the code and potential tests. 
