### PR TITLE
Add support for $ignore_time and $ip options on people properties

### DIFF
--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -33,7 +33,7 @@ module Mixpanel::Person
   protected
 
   def engage(action, distinct_id, properties, options)
-    default  =  {:async => @async, :url => PERSON_URL, :ignore_time => false, :ip => 0}
+    default  =  {:async => @async, :url => PERSON_URL, :ignore_time => false, :ip => 1}
     options = default.merge(options)
 
     data = build_person action, distinct_id, properties, options
@@ -42,6 +42,15 @@ module Mixpanel::Person
   end
 
   def build_person(action, distinct_id, properties, options)
-    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), :$token => @token, :$distinct_id => distinct_id, :$ignore_time => options[:ignore_time], :$ip => options[:ip]}
+    data = {
+      "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES),
+      :$token => @token,
+      :$distinct_id => distinct_id
+    }
+    
+    data[:$ignore_time] = options[:ignore_time] if options[:ignore_time]
+    data[:$ip] = options[:ip] if options[:ip] == 0
+    
+    data
   end
 end

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -33,15 +33,15 @@ module Mixpanel::Person
   protected
 
   def engage(action, distinct_id, properties, options)
-    default  =  {:async => @async, :url => PERSON_URL}
+    default  =  {:async => @async, :url => PERSON_URL, :ignore_time => false, :ip => 0}
     options = default.merge(options)
 
-    data = build_person action, distinct_id, properties
+    data = build_person action, distinct_id, properties, options
     url = "#{options[:url]}?data=#{encoded_data(data)}"
     parse_response request(url, options[:async])
   end
 
-  def build_person(action, distinct_id, properties)
-    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), :$token => @token, :$distinct_id => distinct_id }
+  def build_person(action, distinct_id, properties, options)
+    { "$#{action}".to_sym => properties_hash(properties, PERSON_PROPERTIES), :$token => @token, :$distinct_id => distinct_id, :$ignore_time => options[:ignore_time], :$ip => options[:ip]}
   end
 end


### PR DESCRIPTION
Mixpanel supports {$ignore_time: true} and {$ip: 0} properties when setting people properties. This tells mixpanel to not update the "$last_seen" property and the user's ip, respectively, when applying the people properties. These properties are in the same part of the dictionary as $distinct_id (outside of the $set dictionary).
