### PR TITLE
Add Track charge API method

### DIFF
--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -63,6 +63,10 @@ describe Mixpanel::Tracker do
       it "should increment attributes" do
         @mixpanel.increment('person-a', { :tokens => 3, :money => -1 }).should == true
       end
+
+      it "should append charge attributes" do
+        @mixpanel.append_charge('person-a', { :time => Time.now, :amount => 30.00}).should == true
+      end
     end
   end
 


### PR DESCRIPTION
This little patch adds the new "$append" or track_charge() API call to the gem. It uses the People API, but $append behaves a bit different from the increment/set API calls so I had to hack around a few abstracted things.

Also, I noticed there is already an `append` method in the Mixpanel Tracker class, which makes tracking charges using an `append` method impossible. I have chosen to name this new method to `append_charge` in stead, which does break consistency with the Mixpanel API.

I propose renaming the original `append` method that appends an action to the queue in a new pull request. This would break all apps currently making use of it.
