### PR TITLE
Add option to not render the mixpanel scripts.

### DIFF
--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -7,6 +7,7 @@ module Mixpanel
       @app = app
       @token = mixpanel_token
       @options = {
+        :insert_mixpanel_scripts=> true,
         :insert_js_last => false,
         :persist => false,
         :config => {}
@@ -36,7 +37,9 @@ module Mixpanel
           insert_at = part.index(@options[:insert_js_last] ? '</body' : '</head')
           unless insert_at.nil?
             part.insert(insert_at, render_event_tracking_scripts) unless queue.empty?
-            part.insert(insert_at, render_mixpanel_scripts) #This will insert the mixpanel initialization code before the queue of tracking events.
+            if @options[:insert_mixpanel_scripts]
+              part.insert(insert_at, render_mixpanel_scripts) #This will insert the mixpanel initialization code before the queue of tracking events.
+            end
           end
         elsif is_turbolink_request? && is_html_response?
           part.insert(part.index('</body'), render_event_tracking_scripts) unless queue.empty?

--- a/spec/mixpanel/middleware_spec.rb
+++ b/spec/mixpanel/middleware_spec.rb
@@ -194,6 +194,18 @@ describe Mixpanel::Middleware do
           Nokogiri::HTML(last_response.body).search('body script').should_not be_empty
         end
       end
+
+      describe "With no mixpanel scripts" do
+        before do
+          setup_rack_application(DummyApp, {:body => html_document, :headers => {"Content-Type" => "text/html"}}, {:insert_mixpanel_scripts => false})
+          get "/"
+        end
+
+        it "should not insert mixpanel scripts" do
+          Nokogiri::HTML(last_response.body).search('head script').should be_empty
+          Nokogiri::HTML(last_response.body).search('body script').should be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I'm open for naming suggestions for the option. This was requested previously on #22.

My use case is using jQuery Deferred to know when the Mixpanel async script tag finished loading in my custom Mixpanel initialization code.
