### PR TITLE
Bypass the middleware on individual requests by calling Mixpanel::Middleware.skip_this_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ Occasionally you may need to send a request for HTML that you don't want the mid
   });
 ```
 
+Alternatively, you can add this line of code to your controller to temporarily disable the middleware:
+
+ ```ruby
+   Mixpanel::Middleware.skip_this_request
+ ```
+
 ## Examples
 
 ### How to use it from Rails controllers?

--- a/spec/mixpanel/middleware_spec.rb
+++ b/spec/mixpanel/middleware_spec.rb
@@ -47,6 +47,18 @@ describe Mixpanel::Middleware do
       get "/"
       Nokogiri::HTML(last_response.body).search('script').size.should == 1
     end
+
+    context "when disabling with #skip_this_request" do
+      before{ Mixpanel::Middleware.skip_this_request }
+
+      it "should skip this request but not the next request" do
+        get "/"
+        Nokogiri::HTML(last_response.body).search('script').should be_empty
+        get "/"
+        Nokogiri::HTML(last_response.body).search('script').size.should == 1
+      end
+
+    end
   end
     
   describe "Appending async mixpanel scripts" do


### PR DESCRIPTION
My use case for this was I have some controllers that use segment.io (instead of Mixpanel directly) to syndicate events and I needed to not insert the Mixpanel JS in those controllers only. I hacked together my own solution, but figured it would be nice if that functionality was in the gem!
