### PR TITLE
Add append_register_once to Mixpanel::Person

### DIFF
--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -41,6 +41,10 @@ module Mixpanel::Person
     append 'register', properties_hash(properties, PERSON_PROPERTIES)
   end
 
+  def append_register_once(properties={})
+    append 'register_once', properties_hash(properties, PERSON_PROPERTIES)
+  end
+
   def append_identify(distinct_id)
     append 'identify', distinct_id
   end

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -120,6 +120,12 @@ describe Mixpanel::Tracker do
         @mixpanel.append_register props
         mixpanel_queue_should_include(@mixpanel, 'register', props)
       end
+
+      it "should allow the one-time tracking of super properties in JS" do
+        props = {:user_id => 12345, :gender => 'male'}
+        @mixpanel.append_register_once props
+        mixpanel_queue_should_include(@mixpanel, 'register_once', props)
+      end
     end
   end
 


### PR DESCRIPTION
Added support for [register_once](https://mixpanel.com/docs/integration-libraries/javascript-full-api#register_once) via the middleware.

This lets you specify a super property that won't be overwritten if it's already set.
