### PR TITLE
Change out Base64 encoder + JSON building

### DIFF
--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -53,7 +53,7 @@ module Mixpanel
     end
 
     def encoded_data(parameters)
-      Base64.encode64(JSON.generate(parameters)).gsub(/\n/,'')
+      Base64.strict_encode64 parameters.to_json
     end
 
     def request(url, async)


### PR DESCRIPTION
I was finding that the call to MP was always erroring when trying to hit http://api.mixpanel.com/engage.  After peeking at the response in verbose mode, this is what I was getting:

```
{
  status: 0,
  error: "data, invalid base64 encoding"
}
```

I found a reference on their end on how they do Base64 and JSON generation here: https://mixpanel.com/docs/integration-libraries/ruby

This is that implementation swapped in for the previous way.
