### PR TITLE
Delete a user from mixpanel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -53,6 +53,10 @@ module Mixpanel::Person
     append 'people.identify', distinct_id
   end
 
+  def delete(distinct_id)
+    engage 'delete', distinct_id, {}, {}
+  end
+
   protected
 
   def engage(action, request_properties_or_distinct_id, properties, options)

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -75,6 +75,10 @@ describe Mixpanel::Tracker do
       it "should unset property" do
         @mixpanel.unset('person-a', 'property').should == true
       end
+
+      it "should delete a user from mixpanel" do
+        @mixpanel.delete('person-a').should == true
+      end
     end
   end
 


### PR DESCRIPTION
To stay within our account limits I needed to delete some users from mixpanel.

You can delete a user by using
mixpanel.delete(distinct_id)

Also changed the source in the gemfile to use https instead of http
