### PR TITLE
2.2 javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ April 2013
 ----------
 
 * Delete a user from mixpanel (dennisvdvliet)
+* Ability to set_once properties (Michael Glass)
+* Use mixpanel script version 2.2. Replaced person.identify with unified identify. Added person.alias. (Milo Winningham)
 
 Bump: 3.5.2 Feb 24, 2013
 

--- a/README.md
+++ b/README.md
@@ -315,11 +315,11 @@ If you need to remove accidental charges for a person, you can use:
 
 **event_name** and **properties** take the same form as [tracking the event directly](#track-events-directly).
 
-Note that you must call mixpanel.people.identify() in conjunction with People requests like set(). If you make set() requests before 
+Note that you must call mixpanel.identify() in conjunction with People requests like set(). If you make set() requests before
 you identify the user, the change will not be immediately sent to Mixpanel. Mixpanel will wait for you to call identify() and then send the accumulated changes.
 
 ```ruby
-  @mixpanel.append_people_identify distinct_id
+  @mixpanel.append_identify distinct_id
   @mixpanel.append_set properties
 ```
 

--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -98,17 +98,7 @@ module Mixpanel
       <<-EOT
         <!-- start Mixpanel -->
         <script type="text/javascript">
-          (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
-          b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-          '//cdn.mxpnl.com/libs/mixpanel-2.1.min.js';d=c.getElementsByTagName("script")[0];
-          d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
-          var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
-          Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
-          f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
-          'track_forms','register','register_once','unregister','identify','name_tag',
-          'set_config','people.identify','people.set','people.increment'];for(e=0;e<h.length;e++)d(g,h[e]);
-          a._i.push([b,c,f])};a.__SV=1.1;})(document,window.mixpanel||[]);
-
+          (function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src=("https:"===e.location.protocol?"https:":"http:")+'//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f);b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2}})(document,window.mixpanel||[]);
           mixpanel.init("#{@token}");
           mixpanel.set_config(#{@options[:config].to_json});
         </script>
@@ -136,7 +126,7 @@ module Mixpanel
 
     def merge_queue!
       present_hash = {}
-      special_events = ['identify', 'name_tag', 'people.set', 'register']
+      special_events = ['alias', 'identify', 'name_tag', 'people.set', 'register']
       queue.uniq!
 
       queue.reverse_each do |item|

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -1,5 +1,7 @@
 module Mixpanel::Person
-  PERSON_PROPERTIES = %w{email created first_name last_name name last_login username country_code}
+  #from https://mixpanel.com/docs/people-analytics/special-properties
+  PERSON_PROPERTIES = %w{email created first_name last_name name last_login username country_code region city}
+  #from https://mixpanel.com/docs/people-analytics/people-http-specification-insert-data
   PERSON_REQUEST_PROPERTIES = %w{token distinct_id ip ignore_time}
   PERSON_URL = 'http://api.mixpanel.com/engage/'
 
@@ -9,6 +11,10 @@ module Mixpanel::Person
 
   def unset(distinct_id, property, options={})
     engage :unset, distinct_id, property, options
+  end
+
+  def set_once(distinct_id, properties={}, options={})
+    engage :set_once, distinct_id, properties, options
   end
 
   def increment(distinct_id, properties={}, options={})
@@ -25,12 +31,20 @@ module Mixpanel::Person
     engage :append, distinct_id, charge_properties, options
   end
 
+  def delete(distinct_id)
+    engage 'delete', distinct_id, {}, {}
+  end
+
   def reset_charges(distinct_id, options={})
     engage :set, distinct_id, { '$transactions' => [] }, options
   end
 
   def append_set(properties={})
     append 'people.set', properties_hash(properties, PERSON_PROPERTIES)
+  end
+
+  def append_set_once(properties = {})
+    append 'people.set_once', properties_hash(properties, PERSON_PROPERTIES)
   end
 
   def append_increment(property, increment=1)
@@ -51,10 +65,6 @@ module Mixpanel::Person
 
   def append_alias(aliased_id)
     append 'alias', aliased_id
-  end
-
-  def delete(distinct_id)
-    engage 'delete', distinct_id, {}, {}
   end
 
   protected

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -49,8 +49,8 @@ module Mixpanel::Person
     append 'identify', distinct_id
   end
 
-  def append_people_identify(distinct_id)
-    append 'people.identify', distinct_id
+  def append_alias(aliased_id)
+    append 'alias', aliased_id
   end
 
   def delete(distinct_id)

--- a/spec/mixpanel/middleware_spec.rb
+++ b/spec/mixpanel/middleware_spec.rb
@@ -84,7 +84,7 @@ describe Mixpanel::Middleware do
       end
 
       it "should not append mixpanel scripts to head element" do
-        last_response.body.index('var mp_protocol').should be_nil
+        last_response.body.index('window.mixpanel').should be_nil
       end
 
       it "should pass through if the document is not text/html content type" do
@@ -158,7 +158,7 @@ describe Mixpanel::Middleware do
       end
 
       it "should not append mixpanel scripts to head element" do
-        last_response.body.index('var mp_protocol').should be_nil
+        last_response.body.index('window.mixpanel').should be_nil
       end
 
       it "should pass through if the document is not text/html content type" do

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -114,15 +114,15 @@ describe Mixpanel::Tracker do
         mixpanel_queue_should_include(@mixpanel, "identify", "some@one.com")
       end
 
-      it "should allow people.identify to be called through the JS api" do
-        @mixpanel.append_people_identify "an_identity"
-        mixpanel_queue_should_include(@mixpanel, "people.identify", "an_identity")
-      end
-
       it "should allow the tracking of super properties in JS" do
         props = {:user_id => 12345, :gender => 'male'}
         @mixpanel.append_register props
         mixpanel_queue_should_include(@mixpanel, 'register', props)
+      end
+
+      it "should allow alias to be called through the JS api" do
+        @mixpanel.append_alias "new_id"
+        mixpanel_queue_should_include(@mixpanel, "alias", "new_id")
       end
 
       it "should allow the one-time tracking of super properties in JS" do

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -56,6 +56,10 @@ describe Mixpanel::Tracker do
         @mixpanel.set('person-a', { :email => 'me@domain.com', :likeable => false }).should == true
       end
 
+      it "should set an attribute once" do
+        @mixpanel.set_once('person-a', { :email => 'me@domain.com', :likeable => false }).should == true
+      end
+
       it "should set attributes with request properties" do
         @mixpanel.set({ :distinct_id => 'person-a', :ignore_time => true },  { :email => 'me@domain.com', :likeable => false }).should == true
       end


### PR DESCRIPTION
brought over milo's 2.2 changes.  This is not backwards compatible, so bumped version to 4

specifically: people.identify is gone.
