### PR TITLE
Add Alias Helper Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [What is Mixpanel] (#what-is-mixpanel)
 - [What does this Gem do?] (#what-does-this-gem-do)
 - [Install] (#install)
-  - [Rack Middleware] (#rack-middleware) 
+  - [Rack Middleware] (#rack-middleware)
 - [Usage] (#usage)
   - [Initialize Mixpanel] (#initialize-mixpanel)
     - [Track Events Directly](#track-events-directly)
@@ -197,6 +197,12 @@ Example:
 
 ```ruby
 @mixpanel.track 'Purchased credits', { :number => 5, 'First Time Buyer' => true }
+```
+
+If you would like to alias one distinct id to another, you can use the alias helper method:
+
+```ruby
+@mixpanel.alias 'Siddhartha', { distinct_id: previous_distinct_id }
 ```
 
 ### Pixel Based Event Tracking
@@ -445,13 +451,13 @@ end
 ```ruby
 class ApplicationController < ActionController::Base
   before_filter :initialize_env
-  
+
   private
   ##
   # Initialize env for mixpanel
   def initialize_env
-    # Similar to the Resque problem above, we need to help DJ serialize the 
-    # request object. 
+    # Similar to the Resque problem above, we need to help DJ serialize the
+    # request object.
     @request_env = {
       'REMOTE_ADDR' => request.env['REMOTE_ADDR'],
       'HTTP_X_FORWARDED_FOR' => request.env['HTTP_X_FORWARDED_FOR'],
@@ -472,9 +478,9 @@ end
 ```
 **Sample Usage**
 ```ruby
-MixPanel.track("Front Page Load", { 
-                url_type: short_url.uid_type, 
-                page_name: short_url.page.name, 
+MixPanel.track("Front Page Load", {
+                url_type: short_url.uid_type,
+                page_name: short_url.page.name,
                 distinct_id: @client_uid }, @request_env)
 ```
 

--- a/lib/mixpanel/event.rb
+++ b/lib/mixpanel/event.rb
@@ -19,6 +19,14 @@ module Mixpanel::Event
     append 'track', event, track_properties(properties, false)
   end
 
+  def alias(name, properties={}, options={})
+    track_event '$create_alias', properties.merge(:alias => name), options, TRACK_URL
+  end
+
+  def append_alias(aliased_id)
+    append 'alias', aliased_id
+  end
+
   protected
 
   def track_event(event, properties, options, default_url)

--- a/lib/mixpanel/person.rb
+++ b/lib/mixpanel/person.rb
@@ -63,10 +63,6 @@ module Mixpanel::Person
     append 'identify', distinct_id
   end
 
-  def append_alias(aliased_id)
-    append 'alias', aliased_id
-  end
-
   protected
 
   def engage(action, request_properties_or_distinct_id, properties, options)

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -51,6 +51,22 @@ describe Mixpanel::Tracker do
       end
     end
 
+    describe '#alias' do
+      it 'tracks a simple event' do
+        @mixpanel.alias('James Salter').should be true
+      end
+
+      it 'tracks a $create_alias event to the TRACK_URL' do
+        @mixpanel.should_receive(:track_event).with('$create_alias', anything, {}, Mixpanel::Event::TRACK_URL)
+        @mixpanel.alias('Phillip Dean')
+      end
+
+      it 'includes the aliased name in the properties' do
+        @mixpanel.should_receive(:track_event).with('$create_alias', { :alias => 'Cristina Wheatland' }, {}, Mixpanel::Event::TRACK_URL)
+        @mixpanel.alias('Cristina Wheatland')
+      end
+    end
+
     context "Engaging people" do
       it "should set attributes" do
         @mixpanel.set('person-a', { :email => 'me@domain.com', :likeable => false }).should == true


### PR DESCRIPTION
For consistency with the JS API, I added a helper method that mimics `mixpanel.alias` to allow a user to execute something like:

```
Mixpanel.alias('bubbles', {distinct_id: 'walrus'})
```
