### PR TITLE
Make "persist" work with both 301 and 302 redirects

### DIFF
--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -89,7 +89,7 @@ module Mixpanel
     end
 
     def is_trackable_response?
-      return false if @status == 302
+      return false if [301, 302].include?(@status)
       return false if @env.has_key?("HTTP_SKIP_MIXPANEL_MIDDLEWARE")
       is_html_response? || is_javascript_response?
     end


### PR DESCRIPTION
This is important for Rails because [when you setup a redirect in routes.rb, it uses a 301](http://guides.rubyonrails.org/routing.html#redirection).
