### PR TITLE
Add redirect_url to tracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
-  - jruby-18mode # JRuby in 1.8 mode
-  #- jruby-19mode # JRuby in 1.9 mode
-  #- rbx-18mode
-  #- rbx-19mode
-# uncomment this line if your project needs to run something other than `rake`:
-# script: bundle exec rspec spec
+  - jruby-19mode # JRuby in 1.9 mode

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Initialize Mixpanel] (#initialize-mixpanel)
     - [Track Events Directly](#track-events-directly)
     - [Pixel Based Event Tracking](#pixel-based-event-tracking)
+    - [Redirect Based Event Tracking](#redirect-based-event-tracking)
     - [Import Events](#import-events)
     - [Set Person Attributes Directly](#set-person-attributes-directly)
     - [Increment Person Attributes Directly](#increment-person-attributes-directly)
@@ -228,7 +229,13 @@ image_tag @mixpanel.tracking_pixel("Opened Email", { :distinct_id => "bob@email.
 
 Mixpanel docs: https://mixpanel.com/docs/api-documentation/pixel-based-event-tracking
 
+### Redirect Based Event Tracking
 
+```ruby
+@mixpanel.redirect_url "Opened Email", 'http://www.example.com/' { :distinct_id => "bob@email.com", :campaign => "Retarget" }
+```
+
+This allows to track events just when a user clicks a link. It's usually useful for tracking opened emails.
 
 ### Import Events
 

--- a/lib/mixpanel/event.rb
+++ b/lib/mixpanel/event.rb
@@ -11,6 +11,10 @@ module Mixpanel::Event
     build_url event, properties, options.merge(:url => TRACK_URL, :img => true)
   end
 
+  def redirect_url(event, redirect, properties={}, options={})
+    build_url event, properties, options.merge(:url => TRACK_URL, :redirect => CGI::escape(redirect))
+  end
+
   def import(event, properties={}, options={})
     track_event event, properties, options, IMPORT_URL
   end
@@ -53,6 +57,7 @@ module Mixpanel::Event
     url << "&api_key=#{options[:api_key]}" if options.fetch(:api_key, nil)
     url << "&img=1" if options[:img]
     url << "&test=1" if options[:test]
+    url << "&redirect=#{options[:redirect]}" if options[:redirect]
     url
   end
 end

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -41,6 +41,20 @@ describe Mixpanel::Tracker do
       end
     end
 
+    context "Redirect url" do
+      let(:url) { "http://example.com?foo=bar&bar=foo" }
+
+      it "should return a URL" do
+        @mixpanel.redirect_url("Click Email", url).should be_a(String)
+      end
+
+      it "should include a redirect" do
+        encoded_url = CGI::escape(url)
+        @mixpanel.redirect_url("Click Email", url).should include('&redirect=' + encoded_url)
+      end
+
+    end
+
     context "Importing events" do
       it "should import simple events" do
         @mixpanel.import('Sign up').should == true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), "../lib", "mixpanel")
 require 'rack/test'
 require 'fakeweb'
 require 'nokogiri'
+require 'cgi'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
 


### PR DESCRIPTION
I needed this to make tracking urls in my emails. I was just going to use `build_url` (it a great method but it's protected) but I figured a real method is probably the better way to go. I'm flexible on the api, it's the only method that's a departure from the standard `func(event, prop, opt)`. I hope people find it useful.
