### PR TITLE
Track events weren't being sent asynchronously

### DIFF
--- a/lib/mixpanel/event.rb
+++ b/lib/mixpanel/event.rb
@@ -35,7 +35,8 @@ module Mixpanel::Event
 
   def track_event(event, properties, options, default_url)
     default = {:url => default_url, :async => @async, :api_key => @api_key}
-    url = build_url(event, properties, default.merge(options))
+    options = default.merge(options)
+    url = build_url(event, properties, options)
     parse_response request(url, options[:async])
   end
 


### PR DESCRIPTION
Since `options[:async]` is usually `nil` and because we aren't merging `defaults` on to `options` (as we are in [person.rb](https://github.com/zevarito/mixpanel/blob/master/lib/mixpanel/person.rb#L70)), `options[:async]` was `nil` and causing events to be tracked synchronously.
