### PR TITLE
Time.to_i

### DIFF
--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -43,10 +43,12 @@ module Mixpanel
         (@env['HTTP_X_FORWARDED_FOR'] || @env['REMOTE_ADDR'] || '').split(',').last
     end
 
-    # Walk through each property and see if it is in the special_properties.  If so, change the key to have a $ in front of it.
+    # Walk through each property and see if it is in the special_properties.
+    # If so, change the key to have a $ in front of it.
     def properties_hash(properties, special_properties)
       properties.inject({}) do |props, (key, value)|
         key = "$#{key}" if special_properties.include?(key.to_s)
+        value = value.to_i if value.class == Time
         props[key.to_sym] = value
         props
       end

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -201,7 +201,7 @@ describe Mixpanel::Tracker do
 
   describe '#properties_hash' do
     it "base64encodes json formatted data" do
-      properties = { a: 4, b: "foo"}
+      properties = { :a => 4, :b => "foo"}
       special_properties = ["a"]
       hash = @mixpanel.send(:properties_hash, properties, special_properties)
       hash.should eq({ :'$a' => 4, :b => "foo"})
@@ -209,10 +209,10 @@ describe Mixpanel::Tracker do
 
     it "converts Time objects into integers" do
       time = Time.new
-      properties = { a: time, b: "foo"}
+      properties = { :a => time, :b => "foo"}
       special_properties = []
       hash = @mixpanel.send(:properties_hash, properties, special_properties)
-      hash.should eq({ a: time.to_i, b: "foo"})
+      hash.should eq({ :a => time.to_i, :b => "foo"})
     end
   end
 end

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -127,14 +127,18 @@ describe Mixpanel::Tracker do
       end
 
       it "should append simple events" do
-        props = { :time => Time.now, :ip => 'ASDF' }
+        time = Time.now
+        props = { :time => time, :ip => 'ASDF' }
         @mixpanel.append_track "Sign up", props
+        props[:time] = time.to_i
         mixpanel_queue_should_include(@mixpanel, "track", "Sign up", props)
       end
 
       it "should append events with properties" do
-        props = { :referer => 'http://example.com', :time => Time.now, :ip => 'ASDF' }
+        time = Time.now
+        props = { :referer => 'http://example.com', :time => time, :ip => 'ASDF' }
         @mixpanel.append_track "Sign up", props
+        props[:time] = time.to_i
         mixpanel_queue_should_include(@mixpanel, "track", "Sign up", props)
       end
 

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -194,4 +194,21 @@ describe Mixpanel::Tracker do
       w2.should_not == w
     end
   end
+
+  describe '#properties_hash' do
+    it "base64encodes json formatted data" do
+      properties = { a: 4, b: "foo"}
+      special_properties = ["a"]
+      hash = @mixpanel.send(:properties_hash, properties, special_properties)
+      hash.should eq({ :'$a' => 4, :b => "foo"})
+    end
+
+    it "converts Time objects into integers" do
+      time = Time.new
+      properties = { a: time, b: "foo"}
+      special_properties = []
+      hash = @mixpanel.send(:properties_hash, properties, special_properties)
+      hash.should eq({ a: time.to_i, b: "foo"})
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,12 +8,12 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].e
 
 MIX_PANEL_TOKEN = "e2d8b0bea559147844ffab3d607d26a6"
 
-
+# json hashes have string keys, convert to json and back to compare hashes
 def mixpanel_queue_should_include(mixpanel, type, *arguments)
-  mixpanel.queue.each do |event_type, event_arguments|
-    # hashes store keys in an undetermined order.  convert to json and back and compare hash to hash, not json to json
-    unjsonify(event_arguments).should == json_and_back(arguments)
-  end
+  event = mixpanel.queue.detect { |event| event[0] == type }
+  event.should_not be_nil
+  event_arguments = event[1]
+  unjsonify(event_arguments).should == json_and_back(arguments)
 end
 
 def json_and_back array


### PR DESCRIPTION
This should fix #118. It converts `Time` objects to integers when preparing data via `properties_hash`. This also effects the queued events, someone with a little more knowledge then me should verify that's working as expected. But it looks good to me.
