### PR TITLE
fix bugs.

### DIFF
--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -68,7 +68,11 @@ module Mixpanel
     end
 
     def parse_response(response)
-      response.body.to_i == 1
+      if response.respond_to?(:body)
+        response.body.to_i == 1
+      else
+        response.to_i == 1
+      end
     end
 
     def send_async(url, data)

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -29,6 +29,10 @@ describe Mixpanel::Tracker do
       it "should track events with properties" do
         @mixpanel.track('Sign up', { :likeable => true }, { :api_key => 'asdf' }).should == true
       end
+
+      it "should track simple events with async" do
+        @mixpanel.track("Sign up", {}, :async => true).should == true
+      end
     end
 
     context "Tracking pixel" do


### PR DESCRIPTION
Mixpanel::Tracker#post_request will return Net::HTTPResponse, 1 or 0.
