### PR TITLE
Ensure async events are delimited by a newline

### DIFF
--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -78,8 +78,9 @@ module Mixpanel
     def send_async(url, data)
       w = Mixpanel::Tracker.worker
       begin
-        url << "\n"
-        w.write JSON.dump(data.merge(_mixpanel_url: url))
+        raw_data = JSON.dump(data.merge(_mixpanel_url: url))
+        w.write raw_data
+        w.write "\n" unless raw_data.end_with?("\n")
         1
       rescue Errno::EPIPE => e
         Mixpanel::Tracker.dispose_worker w


### PR DESCRIPTION
Inside Tracker#send_async a newline character is appended to the Mixpanel URL (why?). I think this newline should instead be written to the pipe.

We are seeing that JSON.dump doesn't necessarily append a newline to its output, so when the subprocess later attempts to read each event (delimited by a newline), multiple events come in concatenated together (and results in a parse error):

Example (in IRB):
$(-- PROD --)(main):002:0> BizMetrics.track("Test", "TestEvent")
$(-- PROD --)(main):003:0> BizMetrics.track("Test", "TestEvent")
$(-- PROD --)(main):004:0> exit

/xxx/ruby1.9/gems/1.9.1/gems/json-1.7.7/lib/json/common.rb:155:in `parse': 795: unexpected token at '{"data":"xyz","_mixpanel_url":"http://api.mixpanel.com/track/\n\n"}{"data":"xyz","_mixpanel_url":"http://api.mixpanel.com/track/\n\n"}' (JSON::ParserError)
        from /xxx/ruby1.9/gems/1.9.1/gems/json-1.7.7/lib/json/common.rb:155:in`parse'
        from /xxx/ruby1.9/gems/1.9.1/gems/json-1.7.7/lib/json/common.rb:334:in `load'
        from /xxx/ruby1.9/gems/1.9.1/gems/mixpanel-4.0.8/lib/mixpanel/subprocess.rb:24:in`block in class:Subprocess'
        from /xxx/ruby1.9/gems/1.9.1/gems/mixpanel-4.0.8/lib/mixpanel/subprocess.rb:21:in `loop'
        from /xxx/ruby1.9/gems/1.9.1/gems/mixpanel-4.0.8/lib/mixpanel/subprocess.rb:21:in`class:Subprocess'
        from /xxx/ruby1.9/gems/1.9.1/gems/mixpanel-4.0.8/lib/mixpanel/subprocess.rb:7:in `<module:Mixpanel>'
        from /xxx/ruby1.9/gems/1.9.1/gems/mixpanel-4.0.8/lib/mixpanel/subprocess.rb:6:in`<main>'

Also note that with each subsequent invocation the _mixpanel_url gains a newline character (further suggesting the newline should be written to the pipe not appended to the URL).

Line 24 of subprocess.rb is calling JSON.load with the following data (note that two events are concatenated together-- invalid JSON):
'{"data":"xyz","_mixpanel_url":"http://api.mixpanel.com/track/\n\n\n"}{"data":"xyz","_mixpanel_url":"http://api.mixpanel.com/track/\n\n\n"}'
