### PR TITLE
Escape generated javascript in append_* methods

### DIFF
--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -4,6 +4,10 @@ require 'json'
 require 'thread'
 require 'base64'
 
+require 'active_support/concern'
+require 'action_view/helpers/capture_helper'
+require 'action_view/helpers/javascript_helper'
+
 module Mixpanel
   class Tracker
     require 'mixpanel/async'
@@ -13,6 +17,8 @@ module Mixpanel
     extend Mixpanel::Async
     include Mixpanel::Event
     include Mixpanel::Person
+
+    include ActionView::Helpers::JavaScriptHelper
 
     def initialize(token, options={})
       @token = token
@@ -35,7 +41,10 @@ module Mixpanel
     end
 
     def append(type, *args)
-      queue << [type, args.collect {|arg| arg.to_json}]
+      js_args = args.collect do |arg|
+        escape_object_for_js(arg).to_json
+      end
+      queue << [type, js_args]
     end
 
     protected
@@ -84,6 +93,45 @@ module Mixpanel
       rescue Errno::EPIPE => e
         Mixpanel::Tracker.dispose_worker w
         0
+      end
+    end
+
+    private
+
+    # Recursively escape anything in a primitive, array, or hash, in
+    # preparation for jsonifying it
+    def escape_object_for_js(object, i = 0)
+
+      if object.kind_of? Hash
+        # Recursive case
+        Hash.new.tap do |h|
+          object.each do |k, v|
+            h[escape_object_for_js(k, i + 1)] = escape_object_for_js(v, i + 1)
+          end
+        end
+
+      elsif object.kind_of? Enumerable
+        # Recursive case
+        object.map do |elt|
+          escape_object_for_js(elt, i + 1)
+        end
+
+      elsif object.respond_to? :iso8601
+        # Base case - safe object
+        object.iso8601
+
+      elsif object.kind_of?(Numeric)
+        # Base case - safe object
+        object
+
+      elsif [true, false, nil].member?(object)
+        # Base case - safe object
+        object
+
+      else
+        # Base case - use string sanitizer from ActiveSupport
+        escape_javascript(object.to_s)
+
       end
     end
   end

--- a/mixpanel.gemspec
+++ b/mixpanel.gemspec
@@ -17,7 +17,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rack'
   s.add_dependency 'escape'
-  s.add_dependency 'actionpack'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'fakeweb'

--- a/mixpanel.gemspec
+++ b/mixpanel.gemspec
@@ -17,6 +17,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rack'
   s.add_dependency 'escape'
+  s.add_dependency 'actionpack'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'fakeweb'

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -146,6 +146,14 @@ describe Mixpanel::Tracker do
         mixpanel_queue_should_include(@mixpanel, "track", "Sign up", props)
       end
 
+      it "should sanitize property values" do
+        @mixpanel.append_track("Sign up", {:referer => "</script><script>alert('XSS');</script>"})
+        @mixpanel.queue.size.should == 1
+        enqueued = @mixpanel.queue.first
+        properties_json = enqueued[1][1]
+        properties_json.should_not match(%r|</script>|)
+      end
+
       it "should give direct access to queue" do
         @mixpanel.append_track("Sign up", {:referer => 'http://example.com'})
         @mixpanel.queue.size.should == 1

--- a/spec/mixpanel/tracker_spec.rb
+++ b/spec/mixpanel/tracker_spec.rb
@@ -154,6 +154,16 @@ describe Mixpanel::Tracker do
         properties_json.should_not match(%r|</script>|)
       end
 
+      it "should be able to sanitize complex objects" do
+        properties = {'object' => ['foo', {2 => 1, 1 => ['bar', Time.now, nil, {'xss' => "</script><script>alert('XSS');</script>"}]}]}
+        @mixpanel.append_track("Sign up", properties)
+        @mixpanel.queue.size.should == 1
+        enqueued = @mixpanel.queue.first
+        properties_json = enqueued[1][1]
+        properties_json.should_not match(%r|</script>|)
+      end
+
+
       it "should give direct access to queue" do
         @mixpanel.append_track("Sign up", {:referer => 'http://example.com'})
         @mixpanel.queue.size.should == 1


### PR DESCRIPTION
The `append_*` methods write their properties directly to a `<script>` tag without any sanitization - this means that if you're pushing user-generated content to Mixpanel using i.e. `append_track`, the user can inject arbitrary Javascript in the generated page.

This change recursively escapes strings in the properties object using ActionView's `escape_javascript` implementation.
