### PR TITLE
Added support for https on Ruby 1.9.3

### DIFF
--- a/lib/mixpanel/http.rb
+++ b/lib/mixpanel/http.rb
@@ -11,7 +11,7 @@ module Mixpanel
         req.basic_auth uri.user, uri.password if uri.user
         ssl = uri.scheme == 'https' 
 
-        Net::HTTP.start(uri.hostname, uri.port, :use_ssl => ssl) do |http|
+        Net::HTTP.start(uri.host, uri.port, :use_ssl => ssl) do |http|
           http.request(req)
         end
       end

--- a/lib/mixpanel/http.rb
+++ b/lib/mixpanel/http.rb
@@ -1,0 +1,24 @@
+require 'uri'
+require 'net/http'
+
+module Mixpanel
+  module Http
+    class Client
+      def self.post url, data
+        uri = URI(url)
+        req = Net::HTTP::Post.new(uri.request_uri)
+        req.form_data = data
+        req.basic_auth uri.user, uri.password if uri.user
+        ssl = uri.scheme == 'https' 
+
+        Net::HTTP.start(uri.hostname, uri.port, :use_ssl => ssl) do |http|
+          http.request(req)
+        end
+      end
+    end
+
+    def http_client
+      Client
+    end
+  end
+end

--- a/lib/mixpanel/subprocess.rb
+++ b/lib/mixpanel/subprocess.rb
@@ -5,6 +5,9 @@ require 'json'
 
 module Mixpanel
   class Subprocess
+    require 'mixpanel/http'
+    extend Mixpanel::Http
+
     Q = Queue.new
     ENDMARKER = Object.new
 
@@ -24,7 +27,7 @@ module Mixpanel
       data_hash = JSON.load(data)
       if data_hash.is_a?(Hash) && data_hash['_mixpanel_url']
         url = data_hash.delete('_mixpanel_url')
-        Net::HTTP.post_form(::URI.parse(url), data_hash)
+        http_client.post(url, data_hash)
       end
     end
     producer.join

--- a/lib/mixpanel/tracker.rb
+++ b/lib/mixpanel/tracker.rb
@@ -9,10 +9,12 @@ module Mixpanel
     require 'mixpanel/async'
     require 'mixpanel/event'
     require 'mixpanel/person'
+    require 'mixpanel/http'
 
     extend Mixpanel::Async
     include Mixpanel::Event
     include Mixpanel::Person
+    include Mixpanel::Http
 
     def initialize(token, options={})
       @token = token
@@ -66,7 +68,7 @@ module Mixpanel
       if async
         send_async(url, data)
       else
-        Net::HTTP.post_form(::URI.parse(url), data)
+        http_client.post(url, data)
       end
     end
 


### PR DESCRIPTION
Net::HTTP.post_form on Ruby 1.9.3 won't detect the HTTPS protocol and enable SSL. This fix checks the scheme and enables it when necessary.
