### PR TITLE
Support Content-Security-Policy nonce when outputting a script tag

### DIFF
--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -24,6 +24,10 @@ module Mixpanel
     end
 
     def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
       @env = env
 
       @status, @headers, @response = @app.call(env)

--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -151,7 +151,14 @@ module Mixpanel
       output = "try {#{output}} catch(err) {};"
 
       request = ActionDispatch::Request.new @env
-      include_script_tag ? "<script type='text/javascript' nonce='#{request.content_security_policy_nonce}'>#{output}</script>" : output
+
+      if include_script_tag && request.content_security_policy_nonce.present?
+        "<script type='text/javascript' nonce='#{request.content_security_policy_nonce}'>#{output}</script>"
+      elsif include_script_tag
+        "<script type='text/javascript'>#{output}</script>"
+      else
+        output
+      end
     end
   end
 end

--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -150,7 +150,8 @@ module Mixpanel
       output = queue.map {|type, arguments| %(mixpanel.#{type}(#{arguments.join(', ')});) }.join("\n")
       output = "try {#{output}} catch(err) {};"
 
-      include_script_tag ? "<script type='text/javascript'>#{output}</script>" : output
+      request = ActionDispatch::Request.new @env
+      include_script_tag ? "<script type='text/javascript' nonce='#{request.content_security_policy_nonce}'>#{output}</script>" : output
     end
   end
 end


### PR DESCRIPTION
this Gem currently doesn't support a Content-Security-Policy based on nonces, as it outputs the script tag without the nonce which results in the browser rejecting to execute the mixpanel script.

This PR will gracefully check if the request has a nonce in the environment and attaches it to the script tag when it's present. 